### PR TITLE
Custom tabular branch support and mac support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ pip install -e .
 
 ## Run benchmarkings locally
 
-Currently, `tabular` makes use of the [AMLB](https://github.com/openml/automlbenchmark) benchmarking framework, so we will supply the required and optional arguments when running benchmark for tabular. It can only run on the stable and latest(master) build of the framework at the moment. In order to benchmark on a custom branch, changes need to be made on AMLB.
+Currently, `tabular` makes use of the [AMLB](https://github.com/openml/automlbenchmark) benchmarking framework. Required and optional AMLB arguments are specified via configuration file. Sample configuration files are provided in the `sample_configs` directory.
+
+A custom branch of autogluon can be benchmarked by specifying the `amlb_custom_branch` configuration of the form: `https://github.com/REPO/autogluon#BRANCH`
 
 ```
 python ./runbenchmarks.py  --config_file path/to/local_config_file

--- a/runbenchmarks.py
+++ b/runbenchmarks.py
@@ -39,7 +39,8 @@ def get_kwargs(module: str, configs):
                 "framework": f'{configs["framework"]}:{configs["label"]}',
                 "benchmark": configs["amlb_benchmark"],
                 "constraint": configs["amlb_constraint"],
-                "task": configs["amlb_task"],
+                "task": configs.get("amlb_task"),
+                "custom_branch": configs.get("amlb_custom_branch"),
             },
         }
 

--- a/sample_configs/cloud_configs.yaml
+++ b/sample_configs/cloud_configs.yaml
@@ -35,3 +35,5 @@ module_configs:
         - vehicle
     amlb_constraint:
       - test
+    amlb_custom_branch:
+      - https://github.com/gidler/autogluon#gidler_master_w_logging

--- a/sample_configs/local_configs.yaml
+++ b/sample_configs/local_configs.yaml
@@ -14,3 +14,4 @@ label: stable
 amlb_benchmark: test
 amlb_task: iris
 amlb_constraint: test
+amlb_custom_branch: https://github.com/gidler/autogluon#gidler_master_w_logging

--- a/src/autogluon/bench/frameworks/tabular/setup.sh
+++ b/src/autogluon/bench/frameworks/tabular/setup.sh
@@ -13,5 +13,5 @@ source $DIR/.venv/bin/activate
 # install latest AMLB
 pip install --upgrade pip
 pip install --upgrade setuptools wheel
-git -c clone --depth 1 --branch stable https://github.com/openml/automlbenchmark.git $DIR/automlbenchmark
+git clone --depth 1 --branch stable https://github.com/openml/automlbenchmark.git $DIR/automlbenchmark
 pip install -r $DIR/automlbenchmark/requirements.txt

--- a/src/autogluon/bench/frameworks/tabular/setup.sh
+++ b/src/autogluon/bench/frameworks/tabular/setup.sh
@@ -13,5 +13,5 @@ source $DIR/.venv/bin/activate
 # install latest AMLB
 pip install --upgrade pip
 pip install --upgrade setuptools wheel
-git clone --depth 1 --branch stable https://github.com/openml/automlbenchmark.git $DIR/automlbenchmark
+git -c clone --depth 1 --branch stable https://github.com/openml/automlbenchmark.git $DIR/automlbenchmark
 pip install -r $DIR/automlbenchmark/requirements.txt

--- a/src/autogluon/bench/frameworks/tabular/tabular_benchmark.py
+++ b/src/autogluon/bench/frameworks/tabular/tabular_benchmark.py
@@ -1,7 +1,8 @@
 import os
 import subprocess
-import yaml
 import tempfile
+
+import yaml
 
 from autogluon.bench.benchmark import Benchmark
 

--- a/src/autogluon/bench/frameworks/tabular/tabular_benchmark.py
+++ b/src/autogluon/bench/frameworks/tabular/tabular_benchmark.py
@@ -48,7 +48,7 @@ class TabularBenchmark(Benchmark):
 
         if custom_branch is not None:
 
-            custom_repo, custom_branch_name = tuple(custom_branch.split('#'))
+            custom_repo, custom_branch_name = tuple(custom_branch.split("#"))
 
             temp_dirpath = tempfile.mkdtemp()
             custom_framework_name = "AutoGluon_dev"
@@ -57,25 +57,20 @@ class TabularBenchmark(Benchmark):
             custom_config_contents = {
                 "frameworks": {
                     "definition_file": ["{root}/resources/frameworks.yaml", "{user}/frameworks.yaml"],
-                    "allow_duplicates": "true"
+                    "allow_duplicates": "true",
                 }
             }
 
             with open(os.path.join(temp_dirpath, "config.yaml"), "w") as fo:
-               yaml.dump(custom_config_contents, fo)
+                yaml.dump(custom_config_contents, fo)
 
             custom_framework_contents = {
-                custom_framework_name: {
-                    "extends": "AutoGluon",
-                    "repo": custom_repo,
-                    "version": custom_branch_name
-                }
+                custom_framework_name: {"extends": "AutoGluon", "repo": custom_repo, "version": custom_branch_name}
             }
 
             with open(os.path.join(temp_dirpath, "frameworks.yaml"), "w") as fo:
-               yaml.dump(custom_framework_contents, fo)
+                yaml.dump(custom_framework_contents, fo)
 
             command += ["-c", temp_dirpath]
 
         subprocess.run(command)
-


### PR DESCRIPTION
Description of changes:

The primary purpose of this PR is to make it possible to run custom autogluon branches when running tabular benchmarks. This done via setting an optional `amlb_custom_branch` arg in the config file.

I also attempted to improve support for macOS. The main changes needed were migration from `getopt` to `getopts` as `getopts` works in any posix shell. The downside is that it only supports short args (e.g. `-t` and not `--task`). `getopt` isn't always present on MacOS or may have varying levels of support. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.