### PR TITLE
Remove resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ cd autogluon-bench
 git checkout poc_0.0.1
 
 # create virtual env
-python3.10 -m venv .venv
+python3.9 -m venv .venv
 source .venv/bin/activate
 
 # install autogluon-bench

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
 line-length = 119
-target-version = ['py38', 'py39', 'py310']
+target-version = ['py38', 'py39']
 
 [tool.isort]
 known_first_party = "autogluon"

--- a/runbenchmarks.py
+++ b/runbenchmarks.py
@@ -142,7 +142,7 @@ def run():
         
         if args.remove_resources:
             if failed_jobs:
-                logger.warning("Warning: Some jobs have failed: {failed_jobs}. Resources are not being removed.")
+                logger.warning("Warning: Some jobs have failed: %s. Resources are not being removed.", failed_jobs)
             else:
                 destroy_stack(configs=infra_configs)
     elif configs["mode"] == "local":

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@ addopts = --strict-markers
 xfail_strict = True
 
 [tox]
-envlist = py38, py39, py310
+envlist = py38, py39
 isolated_build = True
 
 [testenv]

--- a/src/autogluon/bench/cloud/aws/batch_stack/stack.py
+++ b/src/autogluon/bench/cloud/aws/batch_stack/stack.py
@@ -7,10 +7,9 @@ import aws_cdk as core
 import boto3
 from aws_cdk import aws_batch_alpha as batch
 from aws_cdk import aws_ec2 as ec2
-from aws_cdk import aws_ecr_assets
+from aws_cdk import aws_ecr_assets as ecr_assets
 from aws_cdk import aws_ecs as ecs
 from aws_cdk import aws_iam as iam
-from aws_cdk import aws_lambda as aws_lambda
 from aws_cdk import aws_s3 as s3
 from constructs import Construct
 
@@ -124,7 +123,7 @@ class BatchJobStack(core.Stack):
         # Currently CDK can only push to the default repo aws-cdk/assets
         # https://github.com/aws/aws-cdk/issues/12597
         # TODO: use https://github.com/cdklabs/cdk-docker-image-deployment
-        docker_image_asset = aws_ecr_assets.DockerImageAsset(
+        docker_image_asset = ecr_assets.DockerImageAsset(
             self,
             f"{prefix}-ecr-docker-image-asset",
             directory=docker_base_dir,
@@ -237,3 +236,9 @@ class BatchJobStack(core.Stack):
         )
         core.CfnOutput(self, "JobQueueARN", value=job_queue.job_queue_arn)
         core.CfnOutput(self, "JobDefinitionARN", value=job_definition.job_definition_arn)
+        core.CfnOutput(
+            self,
+            "EcrRepositoryName",
+            value=docker_image_asset.repository.repository_name,
+        )
+        core.CfnOutput(self, "ImageUri", value=docker_image_asset.image_uri)

--- a/src/autogluon/bench/cloud/aws/deploy.sh
+++ b/src/autogluon/bench/cloud/aws/deploy.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -eo pipefail
+
 STACK_NAME_PREFIX=$1
 STACK_NAME_TAG=$2
 STATIC_RESOURCE_STACK_NAME=$3

--- a/src/autogluon/bench/cloud/aws/destroy.sh
+++ b/src/autogluon/bench/cloud/aws/destroy.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+STATIC_RESOURCE_STACK_NAME=$1
+BATCH_STACK_NAME=$2
+
+
+# Get the stack outputs JSON object
+OUTPUTS_JSON=$(aws cloudformation describe-stacks --stack-name "${BATCH_STACK_NAME}" --query "Stacks[0].Outputs" --output json)
+
+REPOSITORY_NAME=$(echo "${OUTPUTS_JSON}" | jq -r '.[] | select(.OutputKey == "EcrRepositoryName") | .OutputValue')
+IMAGE_URI=$(echo "${OUTPUTS_JSON}" | jq -r '.[] | select(.OutputKey == "ImageUri") | .OutputValue')
+IMAGE_TAG_OR_DIGEST=$(echo "${IMAGE_URI}" | sed -n 's/.*://p')
+
+echo "Destroying $BATCH_STACK_NAME"
+cdk destroy $BATCH_STACK_NAME
+echo "Destroying $STATIC_RESOURCE_STACK_NAME"
+cdk deploy $STATIC_RESOURCE_STACK_NAME
+
+echo "Removing image $IMAGE_TAG_OR_DIGEST from ECR repository $REPOSITORY_NAME."
+aws ecr batch-delete-image --repository-name "${REPOSITORY_NAME}" --image-ids "imageTag=${IMAGE_TAG_OR_DIGEST}"

--- a/src/autogluon/bench/cloud/aws/destroy.sh
+++ b/src/autogluon/bench/cloud/aws/destroy.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -eo pipefail
+
 STATIC_RESOURCE_STACK_NAME=$1
 BATCH_STACK_NAME=$2
 

--- a/src/autogluon/bench/cloud/aws/run_deploy.py
+++ b/src/autogluon/bench/cloud/aws/run_deploy.py
@@ -70,3 +70,13 @@ def deploy_stack(configs: dict = {}):
         ]
     )
     return infra_configs
+
+
+def destroy_stack(configs: dict):
+    subprocess.check_call(
+        [
+            CURRENT_DIR + "/destroy.sh",
+            configs["STATIC_RESOURCE_STACK_NAME"],
+            configs["BATCH_STACK_NAME"],
+        ]
+    )

--- a/src/autogluon/bench/cloud/aws/run_deploy.py
+++ b/src/autogluon/bench/cloud/aws/run_deploy.py
@@ -61,7 +61,7 @@ def deploy_stack(configs: dict = {}):
 
     subprocess.check_call(
         [
-            CURRENT_DIR + "/deploy.sh",
+            os.path.join(CURRENT_DIR, "deploy.sh"),
             infra_configs["STACK_NAME_PREFIX"],
             infra_configs["STACK_NAME_TAG"],
             infra_configs["STATIC_RESOURCE_STACK_NAME"],
@@ -75,7 +75,7 @@ def deploy_stack(configs: dict = {}):
 def destroy_stack(configs: dict):
     subprocess.check_call(
         [
-            CURRENT_DIR + "/destroy.sh",
+            os.path.join(CURRENT_DIR, "destroy.sh"),
             configs["STATIC_RESOURCE_STACK_NAME"],
             configs["BATCH_STACK_NAME"],
         ]

--- a/src/autogluon/bench/frameworks/multimodal/exec.py
+++ b/src/autogluon/bench/frameworks/multimodal/exec.py
@@ -21,7 +21,7 @@ def get_args():
         type=str,
         help="Can be one of: dataset name, local path, S3 path, AMLB task ID/name",
     )
-    parser.add_argument("--benchmark_dir", type=str, help="Directory to save metrics.")
+    parser.add_argument("--benchmark_dir", type=str, help="Directory to save benchmarking run.")
 
     args = parser.parse_args()
     return args

--- a/src/autogluon/bench/frameworks/multimodal/exec.py
+++ b/src/autogluon/bench/frameworks/multimodal/exec.py
@@ -21,7 +21,7 @@ def get_args():
         type=str,
         help="Can be one of: dataset name, local path, S3 path, AMLB task ID/name",
     )
-    parser.add_argument("--metrics_dir", type=str, help="Directory to save metrics.")
+    parser.add_argument("--benchmark_dir", type=str, help="Directory to save metrics.")
 
     args = parser.parse_args()
     return args
@@ -72,7 +72,7 @@ def save_metrics(metrics_path: str, metrics):
 
 def run(
     data_path: str,
-    metrics_dir: str,
+    benchmark_dir: str,
     problem_type: str = None,
     label: str = "label",
     presets: str = "best_quality",
@@ -87,6 +87,7 @@ def run(
         label=label,
         problem_type=problem_type,
         presets=presets,
+        path=os.path.join(benchmark_dir, "models"),
     )
     predictor.fit(
         train_data=train_data,
@@ -100,9 +101,9 @@ def run(
         "scores": scores,
         "timestamp": timestamp.strftime("%H:%M:%S"),
     }
-    save_metrics(metrics_dir, metrics)
+    save_metrics(os.path.join(benchmark_dir, "results"), metrics)
 
 
 if __name__ == "__main__":
     args = get_args()
-    run(data_path=args.data_path, metrics_dir=args.metrics_dir)
+    run(data_path=args.data_path, benchmark_dir=args.benchmark_dir)

--- a/src/autogluon/bench/frameworks/multimodal/multimodal_benchmark.py
+++ b/src/autogluon/bench/frameworks/multimodal/multimodal_benchmark.py
@@ -36,7 +36,7 @@ class MultiModalBenchmark(Benchmark):
             exec_path,
             "--data_path",
             data_path,
-            "--metrics_dir",
-            self.metrics_dir,
+            "--benchmark_dir",
+            self.benchmark_dir,
         ]
         subprocess.run(command)

--- a/src/autogluon/bench/frameworks/multimodal/setup.sh
+++ b/src/autogluon/bench/frameworks/multimodal/setup.sh
@@ -13,7 +13,7 @@ repo_name=$(basename -s .git $(echo $GIT_URI))
 git clone --depth 1 --single-branch --branch ${BRANCH} --recurse-submodules ${GIT_URI} $DIR/$repo_name
 
 # create virtual env
-python3.10 -m venv $DIR/.venv
+python3.9 -m venv $DIR/.venv
 source $DIR/.venv/bin/activate
 
 python3 -m pip install --upgrade pip

--- a/src/autogluon/bench/frameworks/multimodal/setup.sh
+++ b/src/autogluon/bench/frameworks/multimodal/setup.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -eo pipefail
+
 GIT_URI=${1:-"https://github.com/autogluon/autogluon.git"}
 BRANCH=${2:-"master"}
 DIR=${3:-"./benchmark_runs/multimodal/test"}  # from root of benchmark run

--- a/src/autogluon/bench/frameworks/tabular/exec.sh
+++ b/src/autogluon/bench/frameworks/tabular/exec.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -eo pipefail
+
 framework=${1}
 benchmark=${2}
 constraint=${3}

--- a/src/autogluon/bench/frameworks/tabular/setup.sh
+++ b/src/autogluon/bench/frameworks/tabular/setup.sh
@@ -9,7 +9,7 @@ if [ ! -d $DIR ]; then
 fi
 
 # create virtual env
-python3.10 -m venv $DIR/.venv
+python3.9 -m venv $DIR/.venv
 source $DIR/.venv/bin/activate
 
 # install latest AMLB

--- a/src/autogluon/bench/frameworks/tabular/setup.sh
+++ b/src/autogluon/bench/frameworks/tabular/setup.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -eo pipefail
+
 DIR=${1:-"./benchmark_runs/tabular/test"}  # from root of project
 
 if [ ! -d $DIR ]; then


### PR DESCRIPTION
Issue #, if available:

Description of changes:

1. Adds the ability to remove AWS resources created in the stack. Resources are retained by default, but when given the option `--remove_resources` to `./runbenchmark.py`, we will remove resources once all the jobs are successfully completed.
2. Adds a function ƒor user to delete metrics saved on local and S3.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.