### PR TITLE
Link metrics with config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,7 +108,7 @@ celerybeat.pid
 
 # Environments
 .env
-.venv
+.venv*/
 env/
 venv/
 ENV/

--- a/runbenchmarks.py
+++ b/runbenchmarks.py
@@ -78,9 +78,13 @@ def run_benchmark(configs: dict, split_id: Optional[str] = None):
         "tabular": TabularBenchmark,
     }
     module_name = configs["module"]
-    benchmark_name = configs["benchmark_name"]
-    if split_id:
+    default_benchmark_name = "ag_bench"
+    benchmark_name = configs.get("benchmark_name", default_benchmark_name)
+    if benchmark_name is None:
+        benchmark_name = default_benchmark_name
+    if split_id is not None:
         benchmark_name=f"{benchmark_name}_{split_id}"
+        
     benchmark_class = module_to_benchmark.get(module_name, None)
     if benchmark_class is None:
         raise NotImplementedError

--- a/setup.py
+++ b/setup.py
@@ -102,6 +102,7 @@ version = update_version(version, use_file_if_exists=False, create_file=True)
 
 install_requires = [
     "autogluon.common>=0.7,<1.0",
+    "awscliv2>=2.2.0,<2.3.0",
     "pandas>=1.2.5,<2.0",
     "boto3>=1.26.0,<1.26.99",
     "aws-cdk-lib>=2.0.0,<2.70.0",

--- a/src/autogluon/bench/frameworks/multimodal/exec.py
+++ b/src/autogluon/bench/frameworks/multimodal/exec.py
@@ -28,6 +28,7 @@ def get_args():
     )
 
     parser.add_argument("--benchmark_dir", type=str, help="Directory to save benchmarking run.")
+    parser.add_argument("--metrics_dir", type=str, help="Directory to save benchmarking metrics.")
     parser.add_argument(
         "--time_limit", type=int, default=None, help="Time limit for the AutoGluon benchmark (in seconds)."
     )
@@ -81,6 +82,7 @@ def save_metrics(metrics_path: str, metrics):
 def run(
     dataset_name: str,
     benchmark_dir: str,
+    metrics_dir: str,
     time_limit: Optional[int] = None,
     presets: Optional[str] = None,
     hyperparameters: Optional[dict] = None,
@@ -159,7 +161,7 @@ def run(
         "scores": scores,
         "timestamp": timestamp.strftime("%H:%M:%S"),
     }
-    save_metrics(os.path.join(benchmark_dir, "results"), metrics)
+    save_metrics(metrics_dir, metrics)
 
 
 if __name__ == "__main__":
@@ -170,6 +172,7 @@ if __name__ == "__main__":
     run(
         dataset_name=args.dataset_name,
         benchmark_dir=args.benchmark_dir,
+        metrics_dir=args.metrics_dir,
         time_limit=args.time_limit,
         presets=args.presets,
         hyperparameters=args.hyperparameters,

--- a/src/autogluon/bench/frameworks/multimodal/multimodal_benchmark.py
+++ b/src/autogluon/bench/frameworks/multimodal/multimodal_benchmark.py
@@ -82,6 +82,8 @@ class MultiModalBenchmark(Benchmark):
             dataset_name,
             "--benchmark_dir",
             self.benchmark_dir,
+            "--metrics_dir",
+            self.metrics_dir,
         ]
         if presets is not None and len(presets) > 0:
             command += ["--presets", presets]

--- a/src/autogluon/bench/frameworks/multimodal/requirements.txt
+++ b/src/autogluon/bench/frameworks/multimodal/requirements.txt
@@ -1,1 +1,0 @@
-torchvision<=0.14.1

--- a/tests/unittests/benchmark/test_benchmark.py
+++ b/tests/unittests/benchmark/test_benchmark.py
@@ -1,8 +1,10 @@
 import os
+import tempfile
 import unittest
 from unittest.mock import MagicMock
 
 import pytest
+import yaml
 
 from autogluon.bench.benchmark import Benchmark
 
@@ -42,3 +44,17 @@ def test_upload_metrics(benchmark, temp_dir):
 
         s3_path = mock_upload_file.call_args[0][2]
         assert s3_path.startswith(f"{s3_dir}/file.txt")
+
+
+def test_save_configs():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        benchmark = TempBenchmark("test_benchmark", temp_dir)
+        data = {"key": "value"}
+        benchmark.save_configs(configs=data, file_name="test.yaml")
+
+        file_path = os.path.join(benchmark.metrics_dir, "test.yaml")
+        assert os.path.isfile(file_path)
+
+        with open(file_path, "r") as f:
+            loaded_data = yaml.safe_load(f)
+        assert loaded_data == data


### PR DESCRIPTION
Issue #, if available:

Description of changes:

The PR aims to ID the metrics folder with the same UID assigned to the config file. We also save the config file to the metrics folder for easy access and future compilation for evaluation and reporting.

A few bug fixes have been done.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.