### PR TITLE
deploy in new AWS account

### DIFF
--- a/sample_configs/cloud_configs.yaml
+++ b/sample_configs/cloud_configs.yaml
@@ -1,14 +1,16 @@
 # Infra configurations
-cdk_context:
+cdk_context:  # AWS infra configs used to setup AWS Batch environment with AWS CDK
   CDK_DEPLOY_ACCOUNT: dummy  # required, update with your AWS account
   CDK_DEPLOY_REGION: dummy  # required, update with your desired region
+  METRICS_BUCKET: autogluon-benchmark-metrics  # required, has to be a globally unique name
+  PREFIX: ag-bench  # Used to identify infra resources created, optional, default = ag-bench
+  # DATA_BUCKET: existing-s3-bucket  # optional, required when benchmark on your private datasets on S3
 
 # Benchmark configurations
 module: multimodal  # required
 mode: aws  # required
-benchmark_name: test_yaml  # required
-root_dir: .ag_bench_runs  # optional
-metrics_bucket: autogluon-benchmark-metrics  # required
+benchmark_name: ag_bench  # required
+root_dir: .ag_bench_runs  # optional, default = ".ag_bench_runs"
 
 # Module specific configurations
 # 

--- a/sample_configs/local_configs.yaml
+++ b/sample_configs/local_configs.yaml
@@ -1,9 +1,9 @@
 # Benchmark configurations
 module: multimodal  # required
 mode: local  # required
-benchmark_name: test_local  # required
-metrics_bucket: autogluon-benchmark-metrics  # optional
-root_dir: .ag_bench_runs  # optional
+benchmark_name: ag_bench  # required
+root_dir: .ag_bench_runs  # optional, default = ".ag_bench_runs"
+METRICS_BUCKET: autogluon-benchmark-metrics  # optional, required only if you want to upload metrics to S3
 
 # Multimodal specific
 git_uri#branch: https://github.com/autogluon/autogluon#master  # required

--- a/setup.py
+++ b/setup.py
@@ -102,7 +102,7 @@ def default_setup_args(*, version):
     return setup_args
 
 
-version = "0.0.3"
+version = "0.0.4"
 version = update_version(version, use_file_if_exists=False, create_file=True)
 
 install_requires = [

--- a/src/autogluon/bench/cloud/aws/batch_stack/lambdas/lambda_function.py
+++ b/src/autogluon/bench/cloud/aws/batch_stack/lambdas/lambda_function.py
@@ -178,6 +178,7 @@ def handler(event, context):
     with open(config_file_path, "r") as f:
         configs = yaml.safe_load(f)
 
+    metrics_bucket = configs["cdk_context"]["METRICS_BUCKET"]
     del configs["cdk_context"]
 
     batch_job_queue = os.environ.get("BATCH_JOB_QUEUE")
@@ -186,8 +187,8 @@ def handler(event, context):
     module_configs = configs["module_configs"].pop(configs["module"])
     del configs["module_configs"]
     common_configs = configs
+    common_configs["METRICS_BUCKET"] = metrics_bucket
     common_configs["mode"] = "local"
-    metrics_bucket = common_configs["metrics_bucket"]
     common_configs = {key: [value] if not isinstance(value, list) else value for key, value in common_configs.items()}
 
     if common_configs["module"][0] == "tabular":

--- a/src/autogluon/bench/cloud/aws/batch_stack/stack.py
+++ b/src/autogluon/bench/cloud/aws/batch_stack/stack.py
@@ -94,8 +94,13 @@ class StaticResourceStack(core.Stack):
         region = os.environ["CDK_DEPLOY_REGION"]
         s3_resource = boto3.resource(service_name="s3", region_name=region)
         self.metrics_bucket = self.import_or_create_bucket(resource=s3_resource, bucket_name=self.metrics_bucket_name)
-        self.data_bucket = s3.Bucket.from_bucket_name(self, self.data_bucket_name, bucket_name=self.data_bucket_name)
-
+        if self.data_bucket_name:
+            self.data_bucket = s3.Bucket.from_bucket_name(
+                self, self.data_bucket_name, bucket_name=self.data_bucket_name
+            )
+        else:
+            self.data_bucket = None
+    
     def create_vpc_resources(self):
         """
         Creates VPC resources.
@@ -219,7 +224,8 @@ class BatchJobStack(core.Stack):
 
         metrics_bucket = static_stack.metrics_bucket
         data_bucket = static_stack.data_bucket
-        data_bucket.grant_read(batch_instance_role)
+        if data_bucket is not None:
+            data_bucket.grant_read(batch_instance_role)
         metrics_bucket.grant_read_write(batch_instance_role)
 
         batch_instance_profile = InstanceProfile(self, f"{prefix}-instance-profile", prefix=prefix)

--- a/src/autogluon/bench/cloud/aws/batch_stack/stack.py
+++ b/src/autogluon/bench/cloud/aws/batch_stack/stack.py
@@ -61,32 +61,6 @@ class StaticResourceStack(core.Stack):
             )
         return bucket
 
-    def import_or_create_vpc(self, resource, vpc_name, prefix):
-        """
-        Imports an EC2 VPC if it already exists or creates a new one if it doesn't exist.
-
-        Args:
-            resource: A boto3 EC2 client object.
-            vpc_name: The name of the VPC.
-            prefix: The prefix to use for the VPC.
-
-        Returns:
-            An EC2 VPC object.
-        """
-        filters = [
-            {
-                "Name": "tag:Name",
-                "Values": [vpc_name],
-            }
-        ]
-        response = resource.describe_vpcs(Filters=filters)
-        if response["Vpcs"]:
-            vpc_id = response["Vpcs"][0]["VpcId"]
-            vpc = ec2.Vpc.from_lookup(self, f"{prefix}-vpc", vpc_id=vpc_id)
-        else:
-            vpc = ec2.Vpc(self, f"{prefix}-vpc", vpc_name=vpc_name, max_azs=1)
-        return vpc
-
     def create_s3_resources(self):
         """
         Creates S3 bucket resources.
@@ -101,13 +75,6 @@ class StaticResourceStack(core.Stack):
         else:
             self.data_bucket = None
     
-    def create_vpc_resources(self):
-        """
-        Creates VPC resources.
-        """
-        region = os.environ["CDK_DEPLOY_REGION"]
-        ec2_client = boto3.client("ec2", region_name=region)
-        self.vpc = self.import_or_create_vpc(resource=ec2_client, vpc_name=self.vpc_name, prefix=self.prefix)
 
     def __init__(self, scope: Construct, id: str, **kwargs) -> None:
         super().__init__(scope, id, **kwargs)
@@ -117,7 +84,7 @@ class StaticResourceStack(core.Stack):
         self.prefix = self.node.try_get_context("STACK_NAME_PREFIX")
 
         self.create_s3_resources()
-        self.create_vpc_resources()
+        self.vpc = ec2.Vpc.from_lookup(self, f"{self.prefix}-vpc", vpc_name=self.vpc_name) if self.vpc_name else None
 
 
 class BatchJobStack(core.Stack):
@@ -157,6 +124,23 @@ class BatchJobStack(core.Stack):
 
         vpc = static_stack.vpc
 
+        if vpc is None:
+            vpc = ec2.Vpc(
+                self,
+                f"{prefix}-vpc",
+                max_azs=2,  # You can increase this number for high availability
+                nat_gateways=1,
+                subnet_configuration=[
+                    ec2.SubnetConfiguration(
+                        name=f"{prefix}-PublicSubnet",
+                        subnet_type=ec2.SubnetType.PUBLIC,
+                    ),
+                    ec2.SubnetConfiguration(
+                        name=f"{prefix}-PrivateSubnet",
+                        subnet_type=ec2.SubnetType.PRIVATE_WITH_EGRESS,
+                    ),
+                ],
+            )
         sg = ec2.SecurityGroup(
             self,
             f"{prefix}-security-group",

--- a/src/autogluon/bench/cloud/aws/default_config.yaml
+++ b/src/autogluon/bench/cloud/aws/default_config.yaml
@@ -1,11 +1,8 @@
 CDK_DEPLOY_ACCOUNT: dummy
 CDK_DEPLOY_REGION: dummy
-PREFIX: ag-bench-test
+PREFIX: ag-bench
 MAX_MACHINE_NUM: 20
 BLOCK_DEVICE_VOLUME: 100
 RESERVED_MEMORY_SIZE: 15000
 INSTANCE: g4dn.2xlarge
-METRICS_BUCKET: autogluon-benchmark-metrics
-DATA_BUCKET: automl-mm-bench
-VPC_NAME: automm-batch-stack/automm-vpc
-LAMBDA_FUNCTION_NAME: ag-bench-test-job-function
+LAMBDA_FUNCTION_NAME: ag-bench-job

--- a/src/autogluon/bench/cloud/aws/stack_handler.py
+++ b/src/autogluon/bench/cloud/aws/stack_handler.py
@@ -53,7 +53,7 @@ def construct_context(custom_configs: dict) -> dict:
         "STATIC_RESOURCE_STACK_NAME": f"{prefix}-static-resource-stack",
         "BATCH_STACK_NAME": f"{prefix}-batch-stack",
         "METRICS_BUCKET": configs["METRICS_BUCKET"],  # bucket to upload metrics
-        "DATA_BUCKET": configs["DATA_BUCKET"],  # bucket to download data
+        "DATA_BUCKET": configs.get("DATA_BUCKET", None),  # bucket to download data
         "INSTANCE_TYPES": [configs["INSTANCE"]],  # can be a list of instance families or instance types
         "COMPUTE_ENV_MAXV_CPUS": vcpu_map[configs["INSTANCE"]]
         * configs["MAX_MACHINE_NUM"],  # total max v_cpus in batch compute environment
@@ -65,9 +65,9 @@ def construct_context(custom_configs: dict) -> dict:
         ],  # memory in MB reserved for container, also used for shm_size, i.e. `shared_memory_size`
         "BLOCK_DEVICE_VOLUME": configs["BLOCK_DEVICE_VOLUME"],  # device attached to instance, in GB
         "LAMBDA_FUNCTION_NAME": f"{prefix}-batch-job-function",
-        "VPC_NAME": configs[
-            "VPC_NAME"
-        ],  # it's recommended to share a vpc for all benchmark infra, you can lookup an existing VPC name under aws console -> VPC, if you want to create a new one, assign a new name
+        "VPC_NAME": configs.get(
+            "VPC_NAME", None
+        ),  # it's recommended to share a vpc for all benchmark infra, you can lookup an existing VPC name under aws console -> VPC, if you want to create a new one, assign a new name
     }
     with open(CONTEXT_FILE, "w+") as f:
         try:
@@ -78,7 +78,7 @@ def construct_context(custom_configs: dict) -> dict:
         json.dump(cdk_config, f, indent=2)
         f.close()
     # set environment variables
-    os.environ["CDK_DEPLOY_ACCOUNT"] = configs["CDK_DEPLOY_ACCOUNT"]
+    os.environ["CDK_DEPLOY_ACCOUNT"] = str(configs["CDK_DEPLOY_ACCOUNT"])
     os.environ["CDK_DEPLOY_REGION"] = configs["CDK_DEPLOY_REGION"]
 
     return context_to_parse

--- a/src/autogluon/bench/frameworks/multimodal/exec.py
+++ b/src/autogluon/bench/frameworks/multimodal/exec.py
@@ -148,7 +148,7 @@ def run(
     start_time = time.time()
     predictor.fit(**fit_args)
     end_time = time.time()
-    training_duration = int(end_time - start_time)
+    training_duration = round(end_time - start_time, 1)
 
     evaluate_args = {
         "data": test_data.data,
@@ -163,7 +163,7 @@ def run(
     start_time = time.time()
     scores = predictor.evaluate(**evaluate_args)
     end_time = time.time()
-    predict_duration = int(end_time - start_time)
+    predict_duration = round(end_time - start_time, 1)
 
     metrics = {
         "problem_type": predictor.problem_type,

--- a/src/autogluon/bench/runbenchmark.py
+++ b/src/autogluon/bench/runbenchmark.py
@@ -99,9 +99,9 @@ def run_benchmark(
     logger.info(f"Backing up benchmarking configs to {benchmark.metrics_dir}/configs.yaml")
     _dump_configs(benchmark_dir=benchmark.metrics_dir, configs=configs, file_name="configs.yaml")
 
-    if configs.get("metrics_bucket", None):
+    if configs.get("METRICS_BUCKET", None):
         s3_dir = f"{module_name}{benchmark_dir.split(module_name)[-1]}"
-        benchmark.upload_metrics(s3_bucket=configs["metrics_bucket"], s3_dir=s3_dir)
+        benchmark.upload_metrics(s3_bucket=configs["METRICS_BUCKET"], s3_dir=s3_dir)
 
 
 def upload_config(bucket: str, benchmark_name: str, file: str):
@@ -293,7 +293,7 @@ def run(
         os.environ["AG_BENCH_VERSION"] = agbench_version  # set the installed version for Dockerfile to align with
         infra_configs = deploy_stack(configs=configs.get("cdk_context", {}))
         config_s3_path = upload_config(
-            bucket=configs["metrics_bucket"], benchmark_name=benchmark_name, file=cloud_config_path
+            bucket=infra_configs["METRICS_BUCKET"], benchmark_name=benchmark_name, file=cloud_config_path
         )
         lambda_response = invoke_lambda(configs=infra_configs, config_file=config_s3_path)
         aws_configs = {**infra_configs, **lambda_response}

--- a/tests/unittests/cloud/aws/conftest.py
+++ b/tests/unittests/cloud/aws/conftest.py
@@ -30,7 +30,6 @@ context_values = {
     "CONTAINER_MEMORY": 10000,
     "BLOCK_DEVICE_VOLUME": 100,
     "LAMBDA_FUNCTION_NAME": "test-batch-job-function",
-    "VPC_NAME": "test-vpc",
 }
 
 

--- a/tests/unittests/cloud/aws/test_stack.py
+++ b/tests/unittests/cloud/aws/test_stack.py
@@ -1,11 +1,10 @@
 import os
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import aws_cdk.aws_ec2 as ec2
 import aws_cdk.aws_s3 as s3
 from aws_cdk import App, Stack
 from aws_cdk.aws_batch_alpha import ComputeEnvironment, JobDefinition, JobQueue
-from aws_cdk.aws_ec2 import LaunchTemplate, SecurityGroup
 from aws_cdk.aws_ecr_assets import DockerImageAsset
 from aws_cdk.aws_iam import Role
 from conftest import context_values, env
@@ -15,18 +14,39 @@ from autogluon.bench.cloud.aws.batch_stack.constructs.instance_profile import In
 from autogluon.bench.cloud.aws.batch_stack.stack import BatchJobStack, StaticResourceStack
 
 
-def test_static_resource_stack():
+def test_static_resource_stack_without_vpc():
     app = App()
     for key, value in context_values.items():
         app.node.set_context(key, value)
 
-    with patch.object(StaticResourceStack, "create_s3_resources", MagicMock()) as mock_s3_resources, patch.object(
-        StaticResourceStack, "create_vpc_resources", MagicMock()
-    ) as mock_vpc_resources, patch.dict(os.environ, {"CDK_DEPLOY_REGION": "dummy_region"}):
+    with patch.object(
+        StaticResourceStack,
+        "create_s3_resources",
+        return_value=s3.Bucket(Stack(app, "TestBucketStack"), "DummyBucket"),
+    ) as mock_s3_resources, patch.dict(os.environ, {"CDK_DEPLOY_REGION": "dummy_region"}):
         stack = StaticResourceStack(app, "TestStaticResourceStack", env=env)
 
         mock_s3_resources.assert_called_once()
-        mock_vpc_resources.assert_called_once()
+
+        assert stack.vpc is None
+
+
+def test_static_resource_stack_with_vpc():
+    app = App()
+    for key, value in context_values.items():
+        app.node.set_context(key, value)
+    app.node.set_context("VPC_NAME", "ProvidedVpcName")
+
+    with patch.object(
+        StaticResourceStack,
+        "create_s3_resources",
+        return_value=s3.Bucket(Stack(app, "TestBucketStack"), "DummyBucket"),
+    ) as mock_s3_resources, patch.dict(os.environ, {"CDK_DEPLOY_REGION": "dummy_region"}):
+        stack = StaticResourceStack(app, "TestStaticResourceStack", env=env)
+
+        mock_s3_resources.assert_called_once()
+
+        assert stack.vpc is not None
 
 
 @patch.dict("os.environ", {"CDK_DEPLOY_REGION": "dummy_region", "CDK_DEPLOY_ACCOUNT": "dummy_account"}, clear=True)
@@ -35,18 +55,22 @@ def test_batch_job_stack():
     for key, value in context_values.items():
         app.node.set_context(key, value)
 
-    with patch("autogluon.bench.cloud.aws.batch_stack.stack.StaticResourceStack.create_s3_resources"), patch(
-        "autogluon.bench.cloud.aws.batch_stack.stack.StaticResourceStack.create_vpc_resources"
+    with patch.object(
+        StaticResourceStack,
+        "create_s3_resources",
+        return_value=s3.Bucket(Stack(app, "TestBucketStack"), "DummyBucket"),
     ):
         static_resource_stack = StaticResourceStack(app, "TestStaticResourceStack", env=env)
+
+        assert static_resource_stack.vpc is None
+
         dummy_stack = Stack(app, "DummyVpcStack")
         static_resource_stack.metrics_bucket = s3.Bucket(dummy_stack, "DummyMetricsBucket")
         static_resource_stack.data_bucket = s3.Bucket(dummy_stack, "DummyDataBucket")
-        static_resource_stack.vpc = ec2.Vpc(dummy_stack, "DummyVpc")
 
-        prefix = app.node.try_get_context("STACK_NAME_PREFIX")
         batch_job_stack = BatchJobStack(app, "TestBatchJobStack", static_stack=static_resource_stack, env=env)
-
+        print(batch_job_stack)
+        prefix = app.node.try_get_context("STACK_NAME_PREFIX")
         constructs = [
             (f"{prefix}-security-group", ec2.SecurityGroup),
             (f"{prefix}-ecr-docker-image-asset", DockerImageAsset),
@@ -57,11 +81,19 @@ def test_batch_job_stack():
             (f"{prefix}-compute-environment", ComputeEnvironment),
             (f"{prefix}-job-queue", JobQueue),
             (app.node.try_get_context("LAMBDA_FUNCTION_NAME"), BatchLambdaFunction),
+            ("vpc", ec2.Vpc),
         ]
 
         for construct_id, construct_class in constructs:
-            construct = batch_job_stack.node.try_find_child(construct_id)
-            assert construct is not None, f"{construct_id} not found"
-            assert isinstance(
-                construct, construct_class
-            ), f"{construct_id} is not an instance of {construct_class.__name__}"
+            if construct_id == "vpc":
+                constructs = [c for c in batch_job_stack.node.children if isinstance(c, ec2.Vpc)]
+                assert constructs, "No VPC found in BatchJobStack"
+                assert isinstance(
+                    constructs[0], construct_class
+                ), f"First VPC in BatchJobStack is not an instance of {construct_class.__name__}"
+            else:
+                construct = batch_job_stack.node.try_find_child(construct_id)
+                assert construct is not None, f"{construct_id} not found"
+                assert isinstance(
+                    construct, construct_class
+                ), f"{construct_id} is not an instance of {construct_class.__name__}"


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Mainly fixes bugs and improve experience when deploy in another AWS account.
1. Fixes bugs to make `VPC_NAME` passed from user config.
2. Move new VPC creation to `BatchJobStack`, and leave importing existing VPC in `StaticResourceStack` to fix issue when stack creation is async and VPC is unrecognized  during `BatchJobStack` creation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.