### PR TITLE
Auto generate lambda name

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ npm install -g aws-cdk  # install aws-cdk
 cdk --version  # verify the installation, you might need to update the Node.js version depending on the log.
 ```
 
+If it is the first time using CDK to deploy to an AWS environment (An AWS environment is a combination of an AWS account and Region), please run the following:
+
+```bash
+cdk bootstrap aws://CDK_DEPLOY_ACCOUNT/CDK_DEPLOY_REGION
+```
+
 To initiate benchmarking on the cloud, use the command below:
 
 ```
@@ -114,10 +120,18 @@ This will check the job status every 2 minutes and remove resources after all jo
 If you want to manually remove resources later, use:
 
 ```bash
-agbench destroy-stack STATIC_RESOURCE_STACK_NAME BATCH_STACK_NAME CDK_DEPLOY_ACCOUNT CDK_DEPLOY_REGION
+agbench destroy-stack --config_file `{WORKING_DIR}/{root_dir}/{module}/{benchmark_name}_{timestamp}/aws_configs.yaml`
 ```
 
+Or you can remove specific stacks by running:
+
+```bash
+agbench destroy-stack --static_resource_stack STATIC_RESOURCE_STACK_NAME --batch_stack BATCH_STACK_NAME --cdk_deploy_account CDK_DEPLOY_ACCOUNT --cdk_deploy_region CDK_DEPLOY_REGION
+```
 where you can find all argument values in `{WORKING_DIR}/{root_dir}/{module}/{benchmark_name}_{timestamp}/aws_configs.yaml`.
+
+
+
 
 
 ### Configure the AWS infrastructure

--- a/sample_configs/cloud_configs.yaml
+++ b/sample_configs/cloud_configs.yaml
@@ -55,5 +55,5 @@ module_configs:
         - vehicle
     amlb_constraint:
       - test
-    amlb_custom_branch:
-      - https://github.com/gidler/autogluon#gidler_master_w_logging
+    # amlb_custom_branch:  # optional, `framework` and `label` are overwritten when this is specified 
+    #   - https://github.com/<ACCOUNT>/autogluon#<CUSTOM_BRANCH>

--- a/sample_configs/cloud_configs.yaml
+++ b/sample_configs/cloud_configs.yaml
@@ -2,8 +2,8 @@
 cdk_context:  # AWS infra configs used to setup AWS Batch environment with AWS CDK
   CDK_DEPLOY_ACCOUNT: dummy  # required, update with your AWS account
   CDK_DEPLOY_REGION: dummy  # required, update with your desired region
-  METRICS_BUCKET: autogluon-benchmark-metrics  # required, has to be a globally unique name
   PREFIX: ag-bench  # Used to identify infra resources created, optional, default = ag-bench
+  METRICS_BUCKET: autogluon-benchmark-metrics  # required, has to be a globally unique name
   # DATA_BUCKET: existing-s3-bucket  # optional, required when benchmark on your private datasets on S3
 
 # Benchmark configurations

--- a/sample_configs/local_configs.yaml
+++ b/sample_configs/local_configs.yaml
@@ -20,4 +20,4 @@ label: stable  # required
 amlb_benchmark: test  # optional
 amlb_task: iris  # optional
 amlb_constraint: test  # optional
-amlb_custom_branch: https://github.com/gidler/autogluon#gidler_master_w_logging  # optional
+# amlb_custom_branch: https://github.com/<ACCOUNT>/autogluon#<CUSTOM_BRANCH>  # optional, `framework` and `label` are overwritten when this is specified 

--- a/src/autogluon/bench/cloud/aws/batch_stack/stack.py
+++ b/src/autogluon/bench/cloud/aws/batch_stack/stack.py
@@ -115,7 +115,7 @@ class BatchJobStack(core.Stack):
         container_vcpu = self.node.try_get_context("CONTAINER_VCPU")
         container_memory = self.node.try_get_context("CONTAINER_MEMORY")
         block_device_volume = self.node.try_get_context("BLOCK_DEVICE_VOLUME")
-        lambda_function_name = self.node.try_get_context("LAMBDA_FUNCTION_NAME")
+        lambda_function_name = self.node.try_get_context("LAMBDA_FUNCTION_NAME") + "-" + prefix
 
         instances = []
         for instance in instance_types:

--- a/src/autogluon/bench/cloud/aws/deploy.sh
+++ b/src/autogluon/bench/cloud/aws/deploy.sh
@@ -46,8 +46,8 @@ ECR_REPO=763104351884.dkr.ecr.us-east-1.amazonaws.com
 aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin $ECR_REPO
 
 echo "Running CDK deploy"
-cdk deploy --app $CDK_PATH $STATIC_RESOURCE_STACK_NAME
-cdk deploy --app $CDK_PATH $BATCH_STACK_NAME
+cdk deploy --app $CDK_PATH $STATIC_RESOURCE_STACK_NAME --require-approval never
+cdk deploy --app $CDK_PATH $BATCH_STACK_NAME --require-approval never
 
 # Workaround for lack of support from CDK
 update_shm_size

--- a/src/autogluon/bench/cloud/aws/destroy.sh
+++ b/src/autogluon/bench/cloud/aws/destroy.sh
@@ -16,9 +16,9 @@ IMAGE_URI=$(echo "${OUTPUTS_JSON}" | jq -r '.[] | select(.OutputKey == "ImageUri
 IMAGE_TAG_OR_DIGEST=$(echo "${IMAGE_URI}" | sed -n 's/.*://p')
 
 echo "Destroying $BATCH_STACK_NAME"
-cdk destroy --app $CDK_PATH $BATCH_STACK_NAME
+cdk destroy --app $CDK_PATH $BATCH_STACK_NAME --force
 echo "Destroying $STATIC_RESOURCE_STACK_NAME"
-cdk deploy --app $CDK_PATH $STATIC_RESOURCE_STACK_NAME
+cdk destroy --app $CDK_PATH $STATIC_RESOURCE_STACK_NAME --force
 
 echo "Removing image $IMAGE_TAG_OR_DIGEST from ECR repository $REPOSITORY_NAME."
 aws ecr batch-delete-image --repository-name "${REPOSITORY_NAME}" --region $CDK_DEPLOY_REGION --image-ids "imageTag=${IMAGE_TAG_OR_DIGEST}"

--- a/src/autogluon/bench/cloud/aws/stack_handler.py
+++ b/src/autogluon/bench/cloud/aws/stack_handler.py
@@ -84,7 +84,7 @@ def construct_context(custom_configs: dict) -> dict:
     return context_to_parse
 
 
-def deploy_stack(configs: Optional[dict] = None) -> dict:
+def deploy_stack(custom_configs: dict) -> dict:
     """
     Deploys the AWS CloudFormation stack containing the benchmarking infrastructure by calling the deploy.sh
     script and passing it the required command line arguments. Constructs the CDK context using the custom
@@ -98,7 +98,6 @@ def deploy_stack(configs: Optional[dict] = None) -> dict:
         dict: A dictionary containing the CDK context settings used for the deployment.
     """
     cdk_path = _get_temp_cdk_app_path()
-    custom_configs = {} if configs is None else configs
     infra_configs = construct_context(custom_configs=custom_configs)
 
     subprocess.check_call(

--- a/src/autogluon/bench/frameworks/multimodal/multimodal_benchmark.py
+++ b/src/autogluon/bench/frameworks/multimodal/multimodal_benchmark.py
@@ -43,11 +43,12 @@ class MultiModalBenchmark(Benchmark):
         setup_script_path = os.path.abspath(os.path.dirname(__file__)) + "/setup.sh"
         command = [setup_script_path, git_uri, git_branch, self.benchmark_dir, agbench_version]
         result = subprocess.run(command)
-        if result.stdout:
-            logger.info("Successfully set up the environment under %s/.venv.", self.benchmark_dir)
-        elif result.stderr:
+        if result.returncode != 0:
             logger.error(result.stderr)
             sys.exit(1)
+        else:
+            logger.info(result.stdout)
+            logger.info("Successfully set up the environment under %s/.venv.", self.benchmark_dir)
 
     def run(
         self,
@@ -87,4 +88,10 @@ class MultiModalBenchmark(Benchmark):
             command += ["--hyperparameters", json.dumps(hyperparameters)]
         if time_limit is not None:
             command += ["--time_limit", str(time_limit)]
-        subprocess.run(command)
+        result = subprocess.run(command)
+        if result.returncode != 0:
+            logger.error(result.stderr)
+            sys.exit(1)
+        else:
+            logger.info(result.stdout)
+            logger.info(f"Benchmark {self.benchmark_name} on dataset {dataset_name} is complete.")

--- a/src/autogluon/bench/frameworks/tabular/tabular_benchmark.py
+++ b/src/autogluon/bench/frameworks/tabular/tabular_benchmark.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import subprocess
+import sys
 import tempfile
 
 import yaml
@@ -18,10 +19,12 @@ class TabularBenchmark(Benchmark):
         setup_script_path = os.path.abspath(os.path.dirname(__file__)) + "/setup.sh"
         command = [setup_script_path, self.benchmark_dir]
         result = subprocess.run(command)
-        if result.stdout:
-            logging.info("Successfully set up the environment under %s/.venv.", self.benchmark_dir)
-        elif result.stderr:
-            logging.error(result.stderr)
+        if result.returncode != 0:
+            logger.error(result.stderr)
+            sys.exit(1)
+        else:
+            logger.info(result.stdout)
+            logger.info("Successfully set up the environment under %s/.venv.", self.benchmark_dir)
 
     def run(
         self,
@@ -81,4 +84,10 @@ class TabularBenchmark(Benchmark):
 
             command += ["-c", temp_dirpath]
 
-        subprocess.run(command)
+        result = subprocess.run(command)
+        if result.returncode != 0:
+            logger.error(result.stderr)
+            sys.exit(1)
+        else:
+            logger.info(result.stdout)
+            logger.info(f"Benchmark {self.benchmark_name} is complete.")

--- a/src/autogluon/bench/runbenchmark.py
+++ b/src/autogluon/bench/runbenchmark.py
@@ -292,7 +292,7 @@ def run(
             benchmark_dir=benchmark_dir, configs=configs, file_name=os.path.basename(config_file)
         )
         os.environ["AG_BENCH_VERSION"] = agbench_version  # set the installed version for Dockerfile to align with
-        infra_configs = deploy_stack(configs=configs.get("cdk_context", {}))
+        infra_configs = deploy_stack(custom_configs=configs.get("cdk_context", {}))
         config_s3_path = upload_config(
             bucket=infra_configs["METRICS_BUCKET"], benchmark_name=benchmark_name, file=cloud_config_path
         )

--- a/src/autogluon/bench/runbenchmark.py
+++ b/src/autogluon/bench/runbenchmark.py
@@ -156,8 +156,9 @@ def invoke_lambda(configs: dict, config_file: str) -> dict:
 
     lambda_client = boto3.client("lambda", configs["CDK_DEPLOY_REGION"])
     payload = {"config_file": config_file}
+    lambda_function_name = configs["LAMBDA_FUNCTION_NAME"] + "-" + configs["STACK_NAME_PREFIX"]
     response = lambda_client.invoke(
-        FunctionName=configs["LAMBDA_FUNCTION_NAME"], InvocationType="RequestResponse", Payload=json.dumps(payload)
+        FunctionName=lambda_function_name, InvocationType="RequestResponse", Payload=json.dumps(payload)
     )
     response = json.loads(response["Payload"].read().decode("utf-8"))
     logger.info("AWS Batch jobs submitted by %s.", configs["LAMBDA_FUNCTION_NAME"])

--- a/src/autogluon/bench/runbenchmark.py
+++ b/src/autogluon/bench/runbenchmark.py
@@ -305,7 +305,7 @@ def run(
             logger.info("Waiting for jobs to complete and then remove the AWS resources created.")
             logger.info(
                 "You can quit at anytime and run \n"
-                "`agbench destroy-stack STATIC_RESOURCE_STACK BATCH_STACK CDK_DEPLOY_ACCOUNT CDK_DEPLOY_REGION` "
+                f"`agbench destroy-stack --config_file {aws_config_path}` "
                 "to delete the stack after jobs have run to completion."
             )
             failed_jobs = wait_for_jobs_to_complete(config_file=aws_config_path)
@@ -319,6 +319,7 @@ def run(
                     batch_stack=infra_configs["BATCH_STACK_NAME"],
                     cdk_deploy_account=infra_configs["CDK_DEPLOY_ACCOUNT"],
                     cdk_deploy_region=infra_configs["CDK_DEPLOY_REGION"],
+                    config_file=None,
                 )
 
     elif configs["mode"] == "local":

--- a/src/autogluon/bench/runbenchmark.py
+++ b/src/autogluon/bench/runbenchmark.py
@@ -181,7 +181,7 @@ def get_job_status(
     The job ids can either be passed in directly or read from a YAML configuration file.
 
     Args:
-        job_ids (list[str], optional):
+        job_ids (List[str], optional):
             A list of job ids to query the status for.
         cdk_deploy_region (str, optional):
             AWS region that the Batch jobs run in.
@@ -218,7 +218,7 @@ def get_job_status(
 
 
 def wait_for_jobs_to_complete(
-    config_file: Optional[str] = None, job_ids: Optional[list[str]] = None, aws_region: Optional[str] = None
+    config_file: Optional[str] = None, job_ids: Optional[List[str]] = None, aws_region: Optional[str] = None
 ):
     while True:
         all_jobs_completed = True

--- a/tests/unittests/benchmark/test_runbenchmarks.py
+++ b/tests/unittests/benchmark/test_runbenchmarks.py
@@ -191,6 +191,7 @@ def test_run_aws_mode_remove_resources(mocker, tmp_path):
         batch_stack=setup["infra_configs"]["BATCH_STACK_NAME"],
         cdk_deploy_account=setup["infra_configs"]["CDK_DEPLOY_ACCOUNT"],
         cdk_deploy_region=setup["infra_configs"]["CDK_DEPLOY_REGION"],
+        config_file=None,
     )
 
 

--- a/tests/unittests/benchmark/test_runbenchmarks.py
+++ b/tests/unittests/benchmark/test_runbenchmarks.py
@@ -164,7 +164,7 @@ def test_run_aws_mode(mocker, tmp_path):
 
     run(setup["config_file"], remove_resources)
 
-    setup["mock_deploy_stack"].assert_called_once_with(configs=setup["cdk_context"])
+    setup["mock_deploy_stack"].assert_called_once_with(custom_configs=setup["cdk_context"])
     setup["mock_upload_config"].assert_called_once_with(
         bucket="test_bucket", benchmark_name="test_benchmark_test_time", file="test_dump"
     )
@@ -179,7 +179,7 @@ def test_run_aws_mode_remove_resources(mocker, tmp_path):
 
     run(setup["config_file"], remove_resources)
 
-    setup["mock_deploy_stack"].assert_called_once_with(configs=setup["cdk_context"])
+    setup["mock_deploy_stack"].assert_called_once_with(custom_configs=setup["cdk_context"])
     setup["mock_upload_config"].assert_called_once_with(
         bucket="test_bucket", benchmark_name="test_benchmark_test_time", file="test_dump"
     )

--- a/tests/unittests/benchmark/test_runbenchmarks.py
+++ b/tests/unittests/benchmark/test_runbenchmarks.py
@@ -1,7 +1,14 @@
 import io
 
-from autogluon.bench.frameworks.tabular.tabular_benchmark import TabularBenchmark
-from autogluon.bench.runbenchmark import download_config, get_kwargs, invoke_lambda, run, run_benchmark, upload_config
+from autogluon.bench.runbenchmark import (
+    download_config,
+    get_job_status,
+    get_kwargs,
+    invoke_lambda,
+    run,
+    run_benchmark,
+    upload_config,
+)
 
 
 def setup_mock(mocker, tmp_path):
@@ -12,17 +19,10 @@ def setup_mock(mocker, tmp_path):
     cdk_context = {
         "METRICS_BUCKET": "test_bucket",
     }
-
-    mock_yaml = mocker.patch("yaml.safe_load")
-    mock_yaml.return_value = {
-        "mode": "aws",
-        "module": "test_module",
-        "cdk_context": cdk_context,
+    job_configs = {
+        "job_id_1": "config_spit_1",
+        "job_id_2": "config_spit_2",
     }
-    mocker.patch("autogluon.bench.runbenchmark._get_benchmark_name", return_value="test_benchmark")
-    mocker.patch("autogluon.bench.runbenchmark.formatted_time", return_value="test_time")
-    mocker.patch("autogluon.bench.runbenchmark._dump_configs", return_value="test_dump")
-    mocker.patch("os.environ.__setitem__")
 
     infra_configs = {
         "STATIC_RESOURCE_STACK_NAME": "test_static_stack",
@@ -31,6 +31,20 @@ def setup_mock(mocker, tmp_path):
         "CDK_DEPLOY_REGION": "test_region",
         "METRICS_BUCKET": "test_bucket",
     }
+    mock_yaml = mocker.patch("yaml.safe_load")
+    yaml_value = {
+        "mode": "aws",
+        "module": "test_module",
+        "cdk_context": cdk_context,
+        "job_configs": job_configs,
+    }
+    yaml_value.update(infra_configs)
+    mock_yaml.return_value = yaml_value
+    mocker.patch("autogluon.bench.runbenchmark._get_benchmark_name", return_value="test_benchmark")
+    mocker.patch("autogluon.bench.runbenchmark.formatted_time", return_value="test_time")
+    mocker.patch("autogluon.bench.runbenchmark._dump_configs", return_value="test_dump")
+    mocker.patch("os.environ.__setitem__")
+
     mock_deploy_stack = mocker.patch("autogluon.bench.runbenchmark.deploy_stack", return_value=infra_configs)
     mock_upload_config = mocker.patch("autogluon.bench.runbenchmark.upload_config", return_value="test_s3_path")
     mock_invoke_lambda = mocker.patch("autogluon.bench.runbenchmark.invoke_lambda", return_value={})
@@ -47,6 +61,7 @@ def setup_mock(mocker, tmp_path):
         "mock_wait_for_jobs": mock_wait_for_jobs,
         "mock_destroy_stack": mock_destroy_stack,
         "cdk_context": cdk_context,
+        "job_configs": job_configs,
     }
 
 
@@ -243,3 +258,39 @@ def test_run_benchmark(mocker):
     upload_metrics_mock.assert_called_once_with(
         s3_bucket=configs["METRICS_BUCKET"], s3_dir=f"{configs['module']}{benchmark_dir.split(configs['module'])[-1]}"
     )
+
+
+def test_get_job_status_with_config_file(mocker, tmp_path):
+    # Setup mock
+    setup = setup_mock(mocker, tmp_path)
+
+    # Additional mock for describe_jobs
+    mock_boto_client = mocker.patch("boto3.client")
+    mock_boto_client.return_value.describe_jobs.side_effect = [
+        {"jobs": [{"status": "SUCCEEDED"}]},
+        {"jobs": [{"status": "FAILED"}]},
+    ]
+
+    expected_status_dict = {"job_id_1": "SUCCEEDED", "job_id_2": "FAILED"}
+    actual_status_dict = get_job_status(config_file=setup["config_file"])
+
+    mock_boto_client.assert_called_once_with("batch", region_name="test_region")
+    assert actual_status_dict == expected_status_dict
+
+
+def test_get_job_status_with_job_ids(mocker, tmp_path):
+    # Setup mock
+    setup = setup_mock(mocker, tmp_path)
+
+    # Additional mock for describe_jobs
+    mock_boto_client = mocker.patch("boto3.client")
+    mock_boto_client.return_value.describe_jobs.side_effect = [
+        {"jobs": [{"status": "SUCCEEDED"}]},
+        {"jobs": [{"status": "FAILED"}]},
+    ]
+
+    expected_status_dict = {"job_id_1": "SUCCEEDED", "job_id_2": "FAILED"}
+    actual_status_dict = get_job_status(job_ids=["job_id_1", "job_id_2"], cdk_deploy_region="test_region")
+
+    mock_boto_client.assert_called_once_with("batch", region_name="test_region")
+    assert actual_status_dict == expected_status_dict

--- a/tests/unittests/benchmark/test_runbenchmarks.py
+++ b/tests/unittests/benchmark/test_runbenchmarks.py
@@ -138,7 +138,11 @@ def test_download_config(mocker, tmp_path):
 
 
 def test_invoke_lambda(mocker):
-    configs = {"CDK_DEPLOY_REGION": "us-east-1", "LAMBDA_FUNCTION_NAME": "test_function"}
+    configs = {
+        "CDK_DEPLOY_REGION": "us-east-1",
+        "LAMBDA_FUNCTION_NAME": "test_function",
+        "STACK_NAME_PREFIX": "prefix",
+    }
     config_file = "test_config_file"
 
     mock_response = {"StatusCode": 200, "Payload": io.BytesIO(b'{"key": "value"}')}
@@ -148,7 +152,7 @@ def test_invoke_lambda(mocker):
     with mocker.patch("boto3.client", return_value=mock_lambda_client):
         invoke_lambda(configs, config_file)
         mock_lambda_client.invoke.assert_called_once_with(
-            FunctionName=configs["LAMBDA_FUNCTION_NAME"],
+            FunctionName=configs["LAMBDA_FUNCTION_NAME"] + "-" + configs["STACK_NAME_PREFIX"],
             InvocationType="RequestResponse",
             Payload='{"config_file": "test_config_file"}',
         )

--- a/tests/unittests/cloud/aws/test_stack.py
+++ b/tests/unittests/cloud/aws/test_stack.py
@@ -70,6 +70,7 @@ def test_batch_job_stack():
 
         batch_job_stack = BatchJobStack(app, "TestBatchJobStack", static_stack=static_resource_stack, env=env)
         prefix = app.node.try_get_context("STACK_NAME_PREFIX")
+        lambda_function_name = app.node.try_get_context("LAMBDA_FUNCTION_NAME")
         constructs = [
             (f"{prefix}-security-group", ec2.SecurityGroup),
             (f"{prefix}-ecr-docker-image-asset", DockerImageAsset),
@@ -79,7 +80,7 @@ def test_batch_job_stack():
             (f"{prefix}-instance-profile", InstanceProfile),
             (f"{prefix}-compute-environment", ComputeEnvironment),
             (f"{prefix}-job-queue", JobQueue),
-            (app.node.try_get_context("LAMBDA_FUNCTION_NAME"), BatchLambdaFunction),
+            (f"{lambda_function_name}-{prefix}", BatchLambdaFunction),
             ("vpc", ec2.Vpc),
         ]
 

--- a/tests/unittests/cloud/aws/test_stack_handler.py
+++ b/tests/unittests/cloud/aws/test_stack_handler.py
@@ -1,10 +1,10 @@
 import importlib.resources
 import json
 import os
-import unittest
-from unittest import mock
+import tempfile
 from unittest.mock import mock_open, patch
 
+import yaml
 from conftest import default_configs
 
 from autogluon.bench.cloud.aws.stack_handler import (
@@ -15,96 +15,170 @@ from autogluon.bench.cloud.aws.stack_handler import (
 )
 
 
-class TestStackHandler(unittest.TestCase):
-    @patch("os.path.dirname")
-    @patch("os.path.join")
-    @patch("tempfile.mkdtemp")
-    @patch("shutil.copy2")
-    @patch("os.chmod")
-    def test_get_temp_cdk_app_path(self, mock_chmod, mock_copy2, mock_mkdtemp, mock_join, mock_dirname):
-        mock_mkdtemp.return_value = "/temp/dir"
-        mock_join.return_value = "/temp/dir/app.py"
-        mock_dirname.return_value = "/dir"
-        result = _get_temp_cdk_app_path()
-        self.assertEqual(result, "/temp/dir/app.py")
+def test_get_temp_cdk_app_path(mocker):
+    mock_mkdtemp = mocker.patch("tempfile.mkdtemp")
+    mock_copy2 = mocker.patch("shutil.copy2")
+    mock_chmod = mocker.patch("os.chmod")
+    mock_join = mocker.patch("os.path.join")
+    mock_resources_path = mocker.patch("importlib.resources.path")
 
-    def test_construct_context(self):
-        custom_configs = {"CDK_DEPLOY_ACCOUNT": "123456789012", "CDK_DEPLOY_REGION": "us-west-1", "PREFIX": "test"}
+    mock_mkdtemp.return_value = "/temp/dir"
+    mock_join.return_value = "/temp/dir/app.py"
 
-        with patch("builtins.open", mock_open(read_data=json.dumps(default_configs))) as mock_file:
-            context = construct_context(custom_configs=custom_configs)
+    mock_resources_path.return_value.__enter__.return_value = "path_to_cdk_app"
 
-        prefix = custom_configs["PREFIX"]
-        self.assertEqual(context["CDK_DEPLOY_ACCOUNT"], custom_configs["CDK_DEPLOY_ACCOUNT"])
-        self.assertEqual(context["CDK_DEPLOY_REGION"], custom_configs["CDK_DEPLOY_REGION"])
-        self.assertEqual(context["STACK_NAME_PREFIX"], prefix)
-        self.assertEqual(context["METRICS_BUCKET"], default_configs["METRICS_BUCKET"])
-        self.assertEqual(context["DATA_BUCKET"], default_configs["DATA_BUCKET"])
-        self.assertEqual(context["VPC_NAME"], default_configs["VPC_NAME"])
-        self.assertEqual(context["STATIC_RESOURCE_STACK_NAME"], f"{prefix}-static-resource-stack")
-        self.assertEqual(context["BATCH_STACK_NAME"], f"{prefix}-batch-stack")
+    result = _get_temp_cdk_app_path()
 
-    @patch("autogluon.bench.cloud.aws.stack_handler.construct_context")
-    @patch("subprocess.check_call")
-    @patch("tempfile.mkdtemp")
-    @patch("shutil.copy2")
-    @patch("os.chmod")
-    @patch("shutil.rmtree")
-    def test_deploy_stack(
-        self, mock_rmtree, mock_chmod, mock_copy2, mock_mktemp, mock_check_call, mock_construct_context
-    ):
-        infra_configs_dict = {
-            "STACK_NAME_PREFIX": "test-prefix",
-            "STACK_NAME_TAG": "benchmark",
-            "STATIC_RESOURCE_STACK_NAME": "test-prefix-static-resource-stack",
-            "BATCH_STACK_NAME": "test-prefix-batch-stack",
-            "CONTAINER_MEMORY": 10000,
-            "CDK_DEPLOY_REGION": "us-west-2",
-        }
-        mock_construct_context.return_value = infra_configs_dict
-        mock_mktemp.return_value = "/path/to/temp_dir"
-        with importlib.resources.path("autogluon.bench.cloud.aws", "stack_handler.py") as file_path:
-            module_base_dir = os.path.dirname(file_path)
+    assert result == "/temp/dir/app.py"
+    mock_mkdtemp.assert_called_once()
+    mock_join.assert_called_once_with("/temp/dir", "app.py")
+    mock_copy2.assert_called_once_with("path_to_cdk_app", "/temp/dir/app.py")
+    mock_chmod.assert_called_once_with("/temp/dir/app.py", 0o755)
 
-        deploy_stack()
-        mock_construct_context.assert_called_once()
-        mock_check_call.assert_called_once_with(
-            [
-                os.path.join(module_base_dir, "deploy.sh"),
-                infra_configs_dict["STACK_NAME_PREFIX"],
-                infra_configs_dict["STACK_NAME_TAG"],
-                infra_configs_dict["STATIC_RESOURCE_STACK_NAME"],
-                infra_configs_dict["BATCH_STACK_NAME"],
-                str(infra_configs_dict["CONTAINER_MEMORY"]),
-                infra_configs_dict["CDK_DEPLOY_REGION"],
-                "/path/to/temp_dir/app.py",
-            ]
-        )
-        mock_rmtree.assert_called_once_with("/path/to/temp_dir")
 
-    @mock.patch("subprocess.check_call")
-    @mock.patch("shutil.rmtree")
-    def test_destroy_stack(self, mock_rmtree, mock_check_call):
-        static_resource_stack = "static_resource_stack"
-        batch_stack = "batch_stack"
-        cdk_deploy_account = "cdk_deploy_account"
-        cdk_deploy_region = "cdk_deploy_region"
+def test_construct_context():
+    custom_configs = {"CDK_DEPLOY_ACCOUNT": "123456789012", "CDK_DEPLOY_REGION": "us-west-1", "PREFIX": "test"}
 
-        cdk_path = "/path/to/temp_dir/app.py"
-        with mock.patch("autogluon.bench.cloud.aws.stack_handler._get_temp_cdk_app_path", return_value=cdk_path):
-            destroy_stack(static_resource_stack, batch_stack, cdk_deploy_account, cdk_deploy_region)
+    with patch("builtins.open", mock_open(read_data=json.dumps(default_configs))) as mock_file:
+        context = construct_context(custom_configs=custom_configs)
 
-        self.assertEqual(os.environ["CDK_DEPLOY_ACCOUNT"], cdk_deploy_account)
-        self.assertEqual(os.environ["CDK_DEPLOY_REGION"], cdk_deploy_region)
-        with importlib.resources.path("autogluon.bench.cloud.aws", "stack_handler.py") as file_path:
-            module_base_dir = os.path.dirname(file_path)
+    prefix = custom_configs["PREFIX"]
+    assert context["CDK_DEPLOY_ACCOUNT"] == custom_configs["CDK_DEPLOY_ACCOUNT"]
+    assert context["CDK_DEPLOY_REGION"] == custom_configs["CDK_DEPLOY_REGION"]
+    assert context["STACK_NAME_PREFIX"] == prefix
+    assert context["METRICS_BUCKET"] == default_configs["METRICS_BUCKET"]
+    assert context["DATA_BUCKET"] == default_configs["DATA_BUCKET"]
+    assert context["VPC_NAME"] == default_configs["VPC_NAME"]
+    assert context["STATIC_RESOURCE_STACK_NAME"] == f"{prefix}-static-resource-stack"
+    assert context["BATCH_STACK_NAME"] == f"{prefix}-batch-stack"
 
-        expected_call_args = [
+
+def test_deploy_stack(mocker):
+    infra_configs_dict = {
+        "STACK_NAME_PREFIX": "test-prefix",
+        "STACK_NAME_TAG": "benchmark",
+        "STATIC_RESOURCE_STACK_NAME": "test-prefix-static-resource-stack",
+        "BATCH_STACK_NAME": "test-prefix-batch-stack",
+        "CONTAINER_MEMORY": 10000,
+        "CDK_DEPLOY_REGION": "us-west-2",
+    }
+    custom_configs = {
+        "METRICS_BUCKET": "test-metrics-bucket",
+        "DATA_BUCKET": "test-data-bucket",
+    }
+
+    mock_subprocess = mocker.patch("subprocess.check_call")
+    with importlib.resources.path("autogluon.bench.cloud.aws", "stack_handler.py") as file_path:
+        module_base_dir = os.path.dirname(file_path)
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        with tempfile.NamedTemporaryFile(dir=temp_dir, delete=False) as temp_file:
+            mock_cdk_path = mocker.patch(
+                "autogluon.bench.cloud.aws.stack_handler._get_temp_cdk_app_path", return_value=temp_file.name
+            )
+            mock_get_context = mocker.patch(
+                "autogluon.bench.cloud.aws.stack_handler.construct_context", return_value=infra_configs_dict
+            )
+
+            deploy_stack(custom_configs=custom_configs)
+
+    assert not os.path.exists(temp_dir)
+    mock_cdk_path.assert_called_once()
+    mock_get_context.assert_called_with(custom_configs=custom_configs)
+    mock_subprocess.assert_called_once_with(
+        [
+            os.path.join(module_base_dir, "deploy.sh"),
+            infra_configs_dict["STACK_NAME_PREFIX"],
+            infra_configs_dict["STACK_NAME_TAG"],
+            infra_configs_dict["STATIC_RESOURCE_STACK_NAME"],
+            infra_configs_dict["BATCH_STACK_NAME"],
+            str(infra_configs_dict["CONTAINER_MEMORY"]),
+            infra_configs_dict["CDK_DEPLOY_REGION"],
+            temp_file.name,
+        ]
+    )
+
+
+def test_destroy_stack(mocker):
+    mock_subprocess = mocker.patch("subprocess.check_call")
+    static_resource_stack = "static_resource_stack"
+    batch_stack = "batch_stack"
+    cdk_deploy_account = "cdk_deploy_account"
+    cdk_deploy_region = "cdk_deploy_region"
+
+    with importlib.resources.path("autogluon.bench.cloud.aws", "stack_handler.py") as file_path:
+        module_base_dir = os.path.dirname(file_path)
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        with tempfile.NamedTemporaryFile(dir=temp_dir, delete=False) as temp_file:
+            mock_cdk_path = mocker.patch(
+                "autogluon.bench.cloud.aws.stack_handler._get_temp_cdk_app_path", return_value=temp_file.name
+            )
+
+            destroy_stack(
+                static_resource_stack=static_resource_stack,
+                batch_stack=batch_stack,
+                cdk_deploy_account=cdk_deploy_account,
+                cdk_deploy_region=cdk_deploy_region,
+                config_file=None,
+            )
+
+    assert not os.path.exists(temp_dir)
+    assert os.environ["CDK_DEPLOY_ACCOUNT"] == cdk_deploy_account
+    assert os.environ["CDK_DEPLOY_REGION"] == cdk_deploy_region
+
+    mock_cdk_path.assert_called_once()
+    mock_subprocess.assert_called_once_with(
+        [
             os.path.join(module_base_dir, "destroy.sh"),
             static_resource_stack,
             batch_stack,
             cdk_deploy_region,
-            cdk_path,
+            temp_file.name,
         ]
-        mock_check_call.assert_called_once_with(expected_call_args)
-        mock_rmtree.assert_called_once_with(os.path.dirname(cdk_path))
+    )
+
+
+def test_destroy_stack_with_config(mocker):
+    mock_subprocess = mocker.patch("subprocess.check_call")
+    configs = {
+        "STATIC_RESOURCE_STACK_NAME": "static_resource_stack",
+        "BATCH_STACK_NAME": "batch_stack",
+        "CDK_DEPLOY_ACCOUNT": "cdk_deploy_account",
+        "CDK_DEPLOY_REGION": "cdk_deploy_region",
+    }
+
+    with importlib.resources.path("autogluon.bench.cloud.aws", "stack_handler.py") as file_path:
+        module_base_dir = os.path.dirname(file_path)
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        with tempfile.NamedTemporaryFile(dir=temp_dir, delete=False) as temp_file:
+            mock_cdk_path = mocker.patch(
+                "autogluon.bench.cloud.aws.stack_handler._get_temp_cdk_app_path", return_value=temp_file.name
+            )
+            config_file_path = os.path.join(temp_dir, "configs.yaml")
+            with open(config_file_path, "w") as f:
+                yaml.dump(configs, f)
+
+            destroy_stack(
+                static_resource_stack=None,
+                batch_stack=None,
+                cdk_deploy_account=None,
+                cdk_deploy_region=None,
+                config_file=config_file_path,
+            )
+
+    assert not os.path.exists(temp_dir)
+    assert os.environ["CDK_DEPLOY_ACCOUNT"] == "cdk_deploy_account"
+    assert os.environ["CDK_DEPLOY_REGION"] == "cdk_deploy_region"
+
+    mock_cdk_path.assert_called_once()
+    mock_subprocess.assert_called_once_with(
+        [
+            os.path.join(module_base_dir, "destroy.sh"),
+            "static_resource_stack",
+            "batch_stack",
+            "cdk_deploy_region",
+            temp_file.name,
+        ]
+    )


### PR DESCRIPTION
Issue #, if available:

Description of changes:
1. Make lambda name a variable that's dependent on infra `PREFIX` so that we can have separate lambda functions for different infra configs
2. Add `--config_file` for `destroy_stack`
3. Quit the container when subprocess fails
4. Some minor bug fixes
5. Update README

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.