### PR TITLE
Add model_failures support to output_context

### DIFF
--- a/src/autogluon/bench/eval/benchmark_context/output_context.py
+++ b/src/autogluon/bench/eval/benchmark_context/output_context.py
@@ -49,7 +49,7 @@ class OutputContext:
 
     @property
     def path_model_failures(self):
-        return self.path + 'model_failures.csv'
+        return self.path + "model_failures.csv"
 
     @property
     def path_infer_speed(self):
@@ -226,13 +226,12 @@ class OutputContext:
         try:
             model_failures_df = self.load_model_failures()
         except Exception as e:
-            print(f'FAILURE:\n'
-                  f'\t{e.__class__.__name__}: {e}')
+            print(f"FAILURE:\n" f"\t{e.__class__.__name__}: {e}")
             return None
         else:
-            results = results.rename(columns={'framework': 'framework_parent'})
-            model_failures_df['id'] = results['id'][0]
-            model_failures_full_df = pd.merge(model_failures_df, results, on='id', how='left')
+            results = results.rename(columns={"framework": "framework_parent"})
+            model_failures_df["id"] = results["id"][0]
+            model_failures_full_df = pd.merge(model_failures_df, results, on="id", how="left")
             return model_failures_full_df
 
     def _merge_leaderboard_with_infer_speed(self, leaderboard: pd.DataFrame) -> pd.DataFrame:

--- a/src/autogluon/bench/eval/benchmark_context/output_context.py
+++ b/src/autogluon/bench/eval/benchmark_context/output_context.py
@@ -48,6 +48,10 @@ class OutputContext:
         return self.path + "leaderboard.csv"
 
     @property
+    def path_model_failures(self):
+        return self.path + 'model_failures.csv'
+
+    @property
     def path_infer_speed(self):
         return self.path + "infer_speed.csv"
 
@@ -92,6 +96,10 @@ class OutputContext:
 
     def load_leaderboard(self) -> pd.DataFrame:
         return load_pd.load(self.path_leaderboard)
+
+    def load_model_failures(self) -> pd.DataFrame:
+        """Load and return the raw model failures file"""
+        return load_pd.load(self.path_model_failures)
 
     def load_infer_speed(self) -> pd.DataFrame:
         return load_pd.load(self.path_infer_speed)
@@ -207,6 +215,25 @@ class OutputContext:
             # print(combined_full)
             print(f"SUCCESS: {print_msg}")
             return combined_full
+
+    def get_model_failures(self) -> pd.DataFrame | None:
+        """
+        Load and return the model failures CSV as a pandas DataFrame if it exists, else return None.
+
+        Will merge with the results to get additional information, akin to the leaderboard output.
+        """
+        results = self.load_results()
+        try:
+            model_failures_df = self.load_model_failures()
+        except Exception as e:
+            print(f'FAILURE:\n'
+                  f'\t{e.__class__.__name__}: {e}')
+            return None
+        else:
+            results = results.rename(columns={'framework': 'framework_parent'})
+            model_failures_df['id'] = results['id'][0]
+            model_failures_full_df = pd.merge(model_failures_df, results, on='id', how='left')
+            return model_failures_full_df
 
     def _merge_leaderboard_with_infer_speed(self, leaderboard: pd.DataFrame) -> pd.DataFrame:
         infer_speed_df = self.load_infer_speed()

--- a/src/autogluon/bench/eval/benchmark_context/output_suite_context.py
+++ b/src/autogluon/bench/eval/benchmark_context/output_suite_context.py
@@ -184,6 +184,23 @@ class OutputSuiteContext:
         leaderboards_df = pd.concat(leaderboards_list, ignore_index=True)
         return leaderboards_df
 
+    def load_model_failures(self) -> List[pd.DataFrame]:
+        return self._loop_func(func=OutputContext.get_model_failures,
+                               input_list=self.output_contexts,
+                               allow_exception=True)
+
+    def aggregate_model_failures(self) -> pd.DataFrame:
+        model_failures_list = self.load_model_failures()
+        none_count = 0
+        for e in model_failures_list:
+            if e is None:
+                none_count += 1
+        if none_count == len(model_failures_list):
+            return pd.DataFrame()
+        else:
+            model_failures_df = pd.concat(model_failures_list, ignore_index=True)
+            return model_failures_df
+
     def get_amlb_info(self) -> List[str]:
         return self._loop_func(func=OutputContext.get_amlb_info, input_list=self.output_contexts)
 
@@ -229,17 +246,14 @@ class OutputSuiteContext:
     def _aggregate_leaderboards_seq(output_contexts, columns_to_keep, with_infer_speed):
         print("starting sequential...")
         num_contexts = len(output_contexts)
-        if not ray.is_initialized():
-            ray.init()
         results = []
         for i, output_context in enumerate(output_contexts):
             results.append(
                 get_single_leaderboard_seq(output_context, columns_to_keep, with_infer_speed, i, num_contexts)
             )
-        result = ray.get(results)
         print("finished sequential...")
-        result = [r for r in result if r is not None]
-        return result
+        results = [r for r in results if r is not None]
+        return results
 
     def construct_zs_dict(self, results_lst=None, zeroshot_metadata_list=None):
         if results_lst is None:

--- a/src/autogluon/bench/eval/benchmark_context/output_suite_context.py
+++ b/src/autogluon/bench/eval/benchmark_context/output_suite_context.py
@@ -185,9 +185,9 @@ class OutputSuiteContext:
         return leaderboards_df
 
     def load_model_failures(self) -> List[pd.DataFrame]:
-        return self._loop_func(func=OutputContext.get_model_failures,
-                               input_list=self.output_contexts,
-                               allow_exception=True)
+        return self._loop_func(
+            func=OutputContext.get_model_failures, input_list=self.output_contexts, allow_exception=True
+        )
 
     def aggregate_model_failures(self) -> pd.DataFrame:
         model_failures_list = self.load_model_failures()


### PR DESCRIPTION
Issue #, if available:

Description of changes:

Add model_failures support to output_context

- Add the ability to aggregate model failure metadata artifacts in AMLB runs.
- Fixed bug where sequential aggregation of leaderboard would crash due to incorrectly using ray.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.