### PR TITLE
Update eval logic

### DIFF
--- a/src/autogluon/bench/eval/benchmark_context/output_context.py
+++ b/src/autogluon/bench/eval/benchmark_context/output_context.py
@@ -104,12 +104,16 @@ class OutputContext:
     def load_infer_speed(self) -> pd.DataFrame:
         return load_pd.load(self.path_infer_speed)
 
-    def load_zeroshot_metadata(self, max_size_mb: float = None) -> dict:
+    def get_zeroshot_metadata_size_bytes(self) -> int:
         s3_bucket = self.get_s3_bucket()
         s3_prefix = self.get_s3_prefix(path=self.path_zeroshot_metadata)
         s3 = boto3.client("s3")
         response = s3.head_object(Bucket=s3_bucket, Key=s3_prefix)
         size = response["ContentLength"]
+        return size
+
+    def load_zeroshot_metadata(self, max_size_mb: float = None) -> dict:
+        size = self.get_zeroshot_metadata_size_bytes()
 
         size_og_mb = round(size / 1e6, 3)
 

--- a/src/autogluon/bench/eval/evaluation/benchmark_evaluator.py
+++ b/src/autogluon/bench/eval/evaluation/benchmark_evaluator.py
@@ -129,7 +129,9 @@ class BenchmarkEvaluator:
         else:
             self._columns_to_keep = None
 
-    def _load_results(self, paths: list | pd.DataFrame, clean_data: bool = False, banned_datasets: list = None) -> pd.DataFrame:
+    def _load_results(
+        self, paths: list | pd.DataFrame, clean_data: bool = False, banned_datasets: list = None
+    ) -> pd.DataFrame:
         """paths can be either a list of file paths or a pandas DataFrame"""
         if isinstance(paths, list):
             results_raw = self.load_results_raw(paths=paths)

--- a/src/autogluon/bench/eval/evaluation/benchmark_evaluator.py
+++ b/src/autogluon/bench/eval/evaluation/benchmark_evaluator.py
@@ -24,8 +24,9 @@ class BenchmarkEvaluator:
         use_tid_as_dataset_name: bool = False,
         filter_errors: bool = False,
         framework_nan_fill: Optional[str] = None,
-        task_metadata: str = "task_metadata_289.csv",
+        task_metadata: str = "task_metadata.csv",
         filter_columns: bool = True,
+        convert_infer_time_to_per_row: bool = True,
         columns_to_keep: Optional[List[str]] = None,
         columns_to_keep_extra: Optional[List[str]] = None,
     ):
@@ -111,6 +112,7 @@ class BenchmarkEvaluator:
                 f"\n\tcolumn counts:\n\t\t{col_count_dict}"
             )
 
+        self.convert_infer_time_to_per_row = convert_infer_time_to_per_row
         self.results_dir = results_dir
         self.results_dir_input = (
             results_dir + "input/prepared/openml/" if results_dir_input is None else results_dir_input
@@ -234,6 +236,10 @@ class BenchmarkEvaluator:
         return load_task_metadata(path=self._task_metadata_path)
 
     def _clean_data(self, results_raw):
+        assert self._task_metadata_path is not None, (
+            f"Cannot clean data if task_metadata is None! "
+            f"Either set `clean_data=False` or specify `task_metadata` during init."
+        )
         task_metadata = self._load_task_metadata()
         task_metadata[DATASET] = task_metadata["name"]
         # FIXME: TEMP
@@ -251,7 +257,8 @@ class BenchmarkEvaluator:
         )
 
         # FIXME: TEMP
-        results_raw[TIME_INFER_S] = results_raw[TIME_INFER_S] / results_raw["NumberOfInstances"] * 10
+        if self.convert_infer_time_to_per_row:
+            results_raw[TIME_INFER_S] = results_raw[TIME_INFER_S] / results_raw["NumberOfInstances"] * 10
         return results_raw
 
     def _update_infer_batch_size(self, results_raw: pd.DataFrame, infer_batch_size: int):

--- a/src/autogluon/bench/eval/evaluation/evaluate_results.py
+++ b/src/autogluon/bench/eval/evaluation/evaluate_results.py
@@ -102,6 +102,14 @@ def evaluate(
     if frameworks is None:
         frameworks = sorted(list(results_raw[FRAMEWORK].unique()))
     elif len(set(frameworks)) != len(frameworks):
+        d = dict()
+        for f in frameworks:
+            if f in d:
+                d[f] += 1
+            else:
+                d[f] = 1
+        d = {k: v for k, v in d.items() if v > 1}
+        print(f"Framework counts:\n{d}")
         raise AssertionError("Framework duplicate detected. Frameworks must be unique.")
     results_raw = results_raw[results_raw[FRAMEWORK].isin(set(frameworks))]
     print(f"Filtered to only valid frameworks: {len(frameworks)} frameworks")

--- a/src/autogluon/bench/eval/evaluation/evaluate_results.py
+++ b/src/autogluon/bench/eval/evaluation/evaluate_results.py
@@ -1,7 +1,7 @@
-from collections import Counter
 import copy
 import logging
 import os
+from collections import Counter
 from typing import Tuple
 
 import pandas as pd

--- a/src/autogluon/bench/eval/evaluation/evaluate_results.py
+++ b/src/autogluon/bench/eval/evaluation/evaluate_results.py
@@ -1,3 +1,4 @@
+from collections import Counter
 import copy
 import logging
 import os
@@ -102,15 +103,11 @@ def evaluate(
     if frameworks is None:
         frameworks = sorted(list(results_raw[FRAMEWORK].unique()))
     elif len(set(frameworks)) != len(frameworks):
-        d = dict()
-        for f in frameworks:
-            if f in d:
-                d[f] += 1
-            else:
-                d[f] = 1
+        d = Counter(frameworks)
         d = {k: v for k, v in d.items() if v > 1}
-        print(f"Framework counts:\n{d}")
-        raise AssertionError("Framework duplicate detected. Frameworks must be unique.")
+        raise AssertionError("Framework duplicate detected. Frameworks must be unique.\n"
+                             "Framework counts:\n"
+                             f"{d}")
     results_raw = results_raw[results_raw[FRAMEWORK].isin(set(frameworks))]
     print(f"Filtered to only valid frameworks: {len(frameworks)} frameworks")
     if len(results_raw) == 0:

--- a/src/autogluon/bench/eval/evaluation/evaluate_results.py
+++ b/src/autogluon/bench/eval/evaluation/evaluate_results.py
@@ -105,9 +105,7 @@ def evaluate(
     elif len(set(frameworks)) != len(frameworks):
         d = Counter(frameworks)
         d = {k: v for k, v in d.items() if v > 1}
-        raise AssertionError("Framework duplicate detected. Frameworks must be unique.\n"
-                             "Framework counts:\n"
-                             f"{d}")
+        raise AssertionError("Framework duplicate detected. Frameworks must be unique.\n" "Framework counts:\n" f"{d}")
     results_raw = results_raw[results_raw[FRAMEWORK].isin(set(frameworks))]
     print(f"Filtered to only valid frameworks: {len(frameworks)} frameworks")
     if len(results_raw) == 0:

--- a/src/autogluon/bench/eval/evaluation/evaluate_utils.py
+++ b/src/autogluon/bench/eval/evaluation/evaluate_utils.py
@@ -29,6 +29,8 @@ def compare_frameworks(
             banned_datasets=banned_datasets,
             folds_to_keep=folds_to_keep,
         )
+        if len(results) == 0:
+            raise AssertionError(f"No results exist after filtering errors!")
     else:
         results = results_raw.copy()
 
@@ -505,3 +507,4 @@ def compute_win_rate_per_dataset(
     out_df = out_df.sort_values(by=["winrate", "bestdiff", "folds", "tierate"], ascending=[False, False, False, True])
     print(f"winrate {f1} vs {f2}")
     print(out_df)
+    return out_df

--- a/src/autogluon/bench/eval/evaluation/metadata/metadata_loader.py
+++ b/src/autogluon/bench/eval/evaluation/metadata/metadata_loader.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pandas as pd
 
-_PATH_TO_DATA = str(Path(__file__).parent.parent.parent / "data" / "metadata")
+_PATH_TO_DATA = str(Path(__file__).parent.parent.parent.parent.parent.parent.parent / "data" / "metadata")
 
 
 def load_task_metadata(path="task_metadata.csv", path_relative_to_data=True, compute_aux_columns=True):

--- a/src/autogluon/bench/eval/evaluation/preprocess/preprocess_utils.py
+++ b/src/autogluon/bench/eval/evaluation/preprocess/preprocess_utils.py
@@ -28,6 +28,13 @@ def fill_missing_results_with_default(framework_nan_fill: str, frameworks_to_fil
     Fill missing results with the result of `framework_nan_fill` framework.
     """
     assert framework_nan_fill is not None
+
+    frameworks_valid = list(results_raw["framework"].unique())
+    assert framework_nan_fill in frameworks_valid
+
+    if frameworks_to_fill is None:
+        frameworks_to_fill = [f for f in frameworks_valid if f != frameworks_valid]
+
     results_nan_fill = results_raw[results_raw["framework"] == framework_nan_fill]
     results_nan_fill = results_nan_fill[["dataset", "fold", "metric_score", "metric_error", "problem_type"]]
     results_nan_fill["time_train_s"] = 3600

--- a/src/autogluon/bench/eval/scripts/run_evaluation_openml.py
+++ b/src/autogluon/bench/eval/scripts/run_evaluation_openml.py
@@ -122,6 +122,7 @@ def evaluate(
     clean_data: bool = True,
     use_tid_as_dataset_name: bool = True,
     filter_errors: bool = False,
+    task_metadata: str = None,
 ) -> (pd.DataFrame, pd.DataFrame, pd.DataFrame, pd.DataFrame, Dict[str, pd.DataFrame]):
     """
     # TODO: Add description
@@ -221,13 +222,6 @@ def evaluate(
     if results_dir_output is None:
         results_dir_output = os.path.join(results_dir, f"output/openml/{output_suffix}/")
 
-    if folds_to_keep is None:
-        folds_to_keep = [i for i in range(10)]
-
-    frameworks_compare_vs_all = []
-    if len(frameworks_compare_vs_all) == 0:
-        frameworks_compare_vs_all = [frameworks_run[0]]
-
     benchmark_evaluator = BenchmarkEvaluator(
         results_dir_input=results_dir_input,
         results_dir_output=results_dir_output,
@@ -235,6 +229,7 @@ def evaluate(
         use_tid_as_dataset_name=use_tid_as_dataset_name,
         framework_nan_fill=framework_nan_fill,
         filter_errors=filter_errors,
+        task_metadata=task_metadata,
     )
 
     results_raw = benchmark_evaluator.load_data(
@@ -248,10 +243,22 @@ def evaluate(
         clean_data=clean_data,
     )
 
+    if frameworks_run is None:
+        frameworks_run = sorted(list(results_raw["framework"].unique()))
+
+    frameworks_compare_vs_all = []
+    if len(frameworks_compare_vs_all) == 0:
+        frameworks_compare_vs_all = [frameworks_run[0]]
+
+    print("[")
+    for i in range(len(frameworks_run)):
+        print(f'\t"{frameworks_run[i]}",')
+    print("]")
+
     folds_to_keep = sorted(results_raw["fold"].unique())
 
     if len(frameworks_run) > 1:
-        compute_win_rate_per_dataset(
+        win_rate_per_dataset_df = compute_win_rate_per_dataset(
             f1=frameworks_run[0], f2=frameworks_run[1], results_raw=results_raw, folds=folds_to_keep
         )
     if compute_z_score and len(frameworks_run) > 1 and len(folds_to_keep) > 1:

--- a/src/autogluon/bench/eval/scripts/run_generate_clean_openml.py
+++ b/src/autogluon/bench/eval/scripts/run_generate_clean_openml.py
@@ -17,6 +17,7 @@ logger = logging.getLogger(__name__)
 @app.command()
 def clean_amlb_results(
     benchmark_name: str = typer.Argument(
+        None,
         help="Benchmark name populated by benchmark run, in format <benchmark_name>_<timestamp>"
     ),
     results_dir: str = typer.Option("data/results/", help="Root directory of raw and prepared results."),

--- a/src/autogluon/bench/eval/scripts/run_generate_clean_openml.py
+++ b/src/autogluon/bench/eval/scripts/run_generate_clean_openml.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 @app.command()
 def clean_amlb_results(
     benchmark_name: str = typer.Argument(
-        None, help="Benchmark name populated by benchmark run, in format <benchmark_name>_<timestamp>"
+        help="Benchmark name populated by benchmark run, in format <benchmark_name>_<timestamp>"
     ),
     results_dir: str = typer.Option("data/results/", help="Root directory of raw and prepared results."),
     results_dir_input: str = typer.Option(
@@ -106,7 +106,7 @@ def clean_and_save_results(
         else:
             save_path = os.path.join(results_dir_output, f"{out_path_prefix}{out_path_suffix}.csv")
         save_pd.save(path=save_path, df=results_raw)
-        logger.info(f"Cleaned results are saved in file: {save_path}")
+        logger.log(30, f"Cleaned results are saved in file: {save_path}")
     return results_raw
 
 

--- a/src/autogluon/bench/eval/scripts/run_generate_clean_openml.py
+++ b/src/autogluon/bench/eval/scripts/run_generate_clean_openml.py
@@ -17,8 +17,7 @@ logger = logging.getLogger(__name__)
 @app.command()
 def clean_amlb_results(
     benchmark_name: str = typer.Argument(
-        None,
-        help="Benchmark name populated by benchmark run, in format <benchmark_name>_<timestamp>"
+        None, help="Benchmark name populated by benchmark run, in format <benchmark_name>_<timestamp>"
     ),
     results_dir: str = typer.Option("data/results/", help="Root directory of raw and prepared results."),
     results_dir_input: str = typer.Option(


### PR DESCRIPTION
Issue #, if available:

Description of changes:

- Update BenchmarkEvaluator to be more flexible by accepting a loaded DataFrame as input (instead of forcing to load from string paths each time)
- Set control for ray worker count in OutputSuiteContext, set max to 64 to avoid AWS throttling.
- Fixed incorrect _PATH_TO_DATA to metadata files
- Fixed missing default value in `run_generate_clean_openml`
- Added verbose logging when framework duplicates exist during eval.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.