### PR TITLE
Add round_error_decimals and treat_folds_as_datasets correction

### DIFF
--- a/src/autogluon/bench/eval/evaluation/evaluate_utils.py
+++ b/src/autogluon/bench/eval/evaluation/evaluate_utils.py
@@ -532,8 +532,8 @@ def convert_to_dataset_fold(df: pd.DataFrame, column_name="dataset", column_type
 
     """
     df = df.copy(deep=True)
-    df["fold"] = df["dataset"].apply(lambda x: x.rsplit("_", 1)[1]).astype(int)
-    df[column_name] = df["dataset"].apply(lambda x: x.rsplit("_", 1)[0]).astype(column_type)
-    df_columns = list(df.columns)
-    df_columns = [column_name, "fold"] + [c for c in df_columns if c not in [column_name, "dataset", "fold"]]
+    df[[column_name, "fold"]] = df["dataset"].str.rsplit("_", n=1, expand=True)
+    df["fold"] = df["fold"].astype(int)
+    df[column_name] = df[column_name].astype(column_type)
+    df_columns = [column_name, "fold"] + [c for c in df.columns if c not in [column_name, "dataset", "fold"]]
     return df[df_columns]  # Reorder so dataset and fold are the first two columns.

--- a/src/autogluon/bench/eval/scripts/run_generate_clean_openml.py
+++ b/src/autogluon/bench/eval/scripts/run_generate_clean_openml.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import os
 from typing import List, Optional
@@ -62,18 +64,18 @@ def clean_amlb_results(
 
 
 def clean_and_save_results(
-    run_name,
-    results_dir="data/results/",
-    results_dir_input=None,
-    results_dir_output=None,
-    file_prefix="results_automlbenchmark",
-    run_name_in_input_path=True,
-    run_name_in_output_path=True,
-    save=True,
-    constraints=None,
-    out_path_prefix="openml_ag_",
-    out_path_suffix="",
-    framework_suffix_column="constraint",
+    run_name: str,
+    results_dir: str = "data/results/",
+    results_dir_input: str | None = None,
+    results_dir_output: str | None = None,
+    file_prefix: str | List[str] = "results_automlbenchmark",
+    run_name_in_input_path: bool = True,
+    run_name_in_output_path: bool = True,
+    save: bool = True,
+    constraints: List[str] | None = None,
+    out_path_prefix: str = "openml_ag_",
+    out_path_suffix: str = "",
+    framework_suffix_column: str = "constraint",
 ) -> pd.DataFrame:
     if results_dir_input is None:
         results_dir_input = os.path.join(results_dir, "input/raw/")
@@ -81,17 +83,21 @@ def clean_and_save_results(
         results_dir_output = os.path.join(results_dir, "input/prepared/openml/")
     run_name_str = f"_{run_name}" if run_name_in_input_path else ""
 
+    if not isinstance(file_prefix, list):
+        file_prefix = [file_prefix]
+
     results_list = []
     if constraints is None:
         constraints = [None]
     for constraint in constraints:
         constraint_str = f"_{constraint}" if constraint is not None else ""
-        results = preprocess_openml.preprocess_openml_input(
-            path=os.path.join(results_dir_input, f"{file_prefix}{constraint_str}{run_name_str}.csv"),
-            framework_suffix=constraint_str,
-            framework_suffix_column=framework_suffix_column,
-        )
-        results_list.append(results)
+        for prefix in file_prefix:
+            results = preprocess_openml.preprocess_openml_input(
+                path=os.path.join(results_dir_input, f"{prefix}{constraint_str}{run_name_str}.csv"),
+                framework_suffix=constraint_str,
+                framework_suffix_column=framework_suffix_column,
+            )
+            results_list.append(results)
 
     results_raw = pd.concat(results_list, ignore_index=True, sort=True)
 


### PR DESCRIPTION
Issue #, if available:

Description of changes:
- Add round_error_decimals, updated precision to 5 decimals from 4 to better handle datasets with very small error values.
- Added treat_folds_as_datasets correction, to have both dataset and fold columns instead of both columns information being contained within "dataset".
- Added type hints to `clean_and_save_results`, added support for specifying a list of `file_prefix` values to be able to concatenate multiple files together into a single cleaned output file.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.