### PR TITLE
Add custom metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ For more customizations, please follow the [example custom configuration folder]
 
 For multimodal benchmarking, set the module to multimodal. Note that multimodal benchmarking directly calls the MultiModalPredictor, bypassing the extra layer of [AMLB](https://github.com/openml/automlbenchmark). Therefore, the required arguments are different from those for tabular or timeseries. Please refer to the [sample multimodal local run configuration file](https://github.com/autogluon/autogluon-bench/blob/master/sample_configs/tabluar_local_configs.yaml). 
 
-We also support customizations on benchmarking framework and datasets by providing `custom_resource_dir` and `custom_dataloader`.
+We also support customizations on benchmarking framework, datasets, and metrics by providing `custom_resource_dir`, `custom_dataloader`, `custom_metrics`.
 
 To define custom frameworks, you can follow the [examples](https://github.com/autogluon/autogluon-bench/tree/master/sample_configs/resources/multimodal_frameworks.yaml).
 1. Create a folder under working directory, e.g. `custom_resources/`
@@ -89,6 +89,14 @@ To add more datasets to your benchmarking jobs. We support custom datasets with 
   5. Make sure you have the proper permission to download the dataset. If running in `AWS mode`, we support downloading from the S3 bucket specified as `DATA_BUCKET` in the `agbench run` configuration under the same AWS Batch deployment account.
 
   Please refer to [here](https://github.com/autogluon/autogluon-bench/tree/master/sample_configs/dataloaders) for more examples.
+
+Adding custom metrics is similar as adding data loaders. Internally, we convert the custom metrics into an [AutoGluon Scorer](https://auto.gluon.ai/stable/tutorials/tabular/advanced/tabular-custom-metric.html) using the `autogluon.core.metrics.make_scorer` function. Follow these steps to set up:
+  1. Create a folder under the working directory, e.g. `custom_metrics/`
+  2. Create a metrics script, `custom_metrics/metrics.py` which has a function defined that returns a metrics score.
+  4. Add `custom_metrics` in the `agbench run` configuration, where `metrics_path`, `function_name` are required. Aditional arguments can be added for the [make_scorer](https://github.com/autogluon/autogluon/blob/a33cc0e084c82cb207c6b98b13b49c1a377f3f0d/core/src/autogluon/core/metrics/__init__.py#L333-L335) function.
+
+  Please refer to [here](https://github.com/autogluon/autogluon-bench/tree/master/sample_configs/custom_metrics) for more examples.
+
 
 ## Run benchmarks on AWS
 

--- a/sample_configs/custom_metrics/sample_metrics.py
+++ b/sample_configs/custom_metrics/sample_metrics.py
@@ -1,0 +1,11 @@
+def f1_score(y_true, y_pred):
+    assert len(y_true) == len(y_pred)
+
+    TP = ((y_true == 1) & (y_pred == 1)).sum()
+    FP = ((y_true == 0) & (y_pred == 1)).sum()
+    FN = ((y_true == 1) & (y_pred == 0)).sum()
+
+    precision = TP / (TP + FP) if TP + FP != 0 else 0
+    recall = TP / (TP + FN) if TP + FN != 0 else 0
+
+    return 2 * precision * recall / (precision + recall) if precision + recall != 0 else 0

--- a/sample_configs/multimodal_cloud_configs.yaml
+++ b/sample_configs/multimodal_cloud_configs.yaml
@@ -21,9 +21,16 @@ dataset_name:  # required
   - shopee
   - melbourne_airbnb
 
-#### Customizations ####
+### Customizations ####
 # custom_resource_dir: sample_configs/resources/  # path to custom multimodal_constraints.yaml and multimodal_frameworks.yaml
 # custom_dataloader:
 #     dataloader_file: sample_configs/dataloaders/vision_dataloader.py   # relative path to WORKDIR
-#     class_name: VisionDataLoaer
+#     class_name: VisionDataLoader
 #     dataset_config_file: sample_configs/dataloaders/vision_datasets.yaml 
+
+# custom_metrics:
+#     metrics_path: sample_configs/custom_metrics/sample_metrics.py
+#     function_name: f1_score
+#     # Other optional parameters can be set, ref: https://auto.gluon.ai/stable/tutorials/tabular/advanced/tabular-custom-metric.html
+#     optimum: 1
+#     greater_is_better: true

--- a/sample_configs/multimodal_local_configs.yaml
+++ b/sample_configs/multimodal_local_configs.yaml
@@ -14,5 +14,11 @@ dataset_name:  # required
 # custom_resource_dir: sample_configs/resources/  # path to custom multimodal_frameworks.yaml and multimodal_constraints.yaml
 # custom_dataloader:
 #     dataloader_file: sample_configs/dataloaders/vision_dataloader.py   # relative path to WORKDIR
-#     class_name: VisionDataLoaer
+#     class_name: VisionDataLoader
 #     dataset_config_file: sample_configs/dataloaders/vision_datasets.yaml 
+# custom_metrics:
+#     metrics_path: sample_configs/custom_metrics/sample_metrics.py
+#     function_name: f1_score
+#     # Other optional parameters can be set, ref: https://auto.gluon.ai/stable/tutorials/tabular/advanced/tabular-custom-metric.html
+#     optimum: 1
+#     greater_is_better: true

--- a/src/autogluon/bench/frameworks/multimodal/multimodal_benchmark.py
+++ b/src/autogluon/bench/frameworks/multimodal/multimodal_benchmark.py
@@ -60,6 +60,7 @@ class MultiModalBenchmark(Benchmark):
         constraint: Optional[str] = None,
         params: Optional[dict] = None,
         custom_dataloader: Optional[dict] = None,
+        custom_metrics: Optional[dict] = None,
     ):
         """
         Runs the benchmark on a given dataset.
@@ -73,7 +74,7 @@ class MultiModalBenchmark(Benchmark):
             framework (str): The name of the framework to use for the benchmark.
             constraint (str): The resource constraint used by benchmarking during AWS mode.
             params (str): The multimodal params.
-            custom_dataloader (Optional[dict], optional): A dictionary containing information about a custom dataloader to use. Defaults to None.
+            custom_dataloader (Optional[dict], None): A dictionary containing information about a custom dataloader to use. Defaults to None.
                                 To define a custom dataloader in the config file:
 
                                 custom_dataloader:
@@ -81,6 +82,13 @@ class MultiModalBenchmark(Benchmark):
                                     class_name: DataLoaderClass
                                     dataset_config_file: path_to/dataset_config.yaml
                                     **kwargs (of DataLoaderClass)
+            custom_metrics (Optional[dict], None): A dictionary containing information about a custom metrics to use. Defaults to None.
+                                To define a custom metrics in the config file:
+
+                                custom_metrics:
+                                    metrics_path: path_to/metrics.py   # relative path to WORKDIR
+                                    function_name: custom_metrics_function
+                                    **kwargs (of )
 
         Returns:
             None
@@ -106,6 +114,8 @@ class MultiModalBenchmark(Benchmark):
             command += ["--params", json.dumps(params)]
         if custom_dataloader is not None:
             command += ["--custom_dataloader", json.dumps(custom_dataloader)]
+        if custom_metrics is not None:
+            command += ["--custom_metrics", json.dumps(custom_metrics)]
         result = subprocess.run(command)
         if result.returncode != 0:
             sys.exit(1)

--- a/src/autogluon/bench/frameworks/multimodal/setup.sh
+++ b/src/autogluon/bench/frameworks/multimodal/setup.sh
@@ -54,5 +54,5 @@ python3 -m pip install -e core[all]
 python3 -m pip install -e features
 python3 -m pip install -e multimodal
 
-python3 -m mim install mmcv
+python3 -m mim install "mmcv==2.0.1"
 python3 -m pip install "mmdet==3.0.0"


### PR DESCRIPTION
Issue #, if available:

Description of changes:

This PR supports custom metrics in multimodal. User supplies a python file which contains a custom metrics function, and adds configurations to the `agbench run` configuration:
```
{
    custom_metrics:
        metrics_path: /path/to/metrics_file.py
        function_name: metrics_function
        optimum: 1/-1
        great_is_better: true/false
        **other args, ref: https://auto.gluon.ai/stable/tutorials/tabular/advanced/tabular-custom-metric.html
}
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.