### PR TITLE
Updates for evaluation and aggregation based on AG 1.0

### DIFF
--- a/src/autogluon/bench/eval/benchmark_context/output_context.py
+++ b/src/autogluon/bench/eval/benchmark_context/output_context.py
@@ -203,7 +203,7 @@ class OutputContext:
                     best_weighted,
                     # best_compressed,
                     # best_distilled,
-                    best_nonweighted,
+                    # best_nonweighted,
                 ],
                 ignore_index=True,
             )

--- a/src/autogluon/bench/eval/benchmark_context/output_suite_context.py
+++ b/src/autogluon/bench/eval/benchmark_context/output_suite_context.py
@@ -321,9 +321,7 @@ class OutputSuiteContext:
         num_paths = len(results_lst)
         aggregated_pred_proba = {}
         aggregated_ground_truth = {}
-        for i, (zeroshot_metadata, scores) in enumerate(
-                zip(zeroshot_metadata_list, results_lst)
-        ):
+        for i, (zeroshot_metadata, scores) in enumerate(zip(zeroshot_metadata_list, results_lst)):
             id = scores["id"][0]
             fold = scores.iloc[0]["fold"]
             task_name = scores.iloc[0]["task"]

--- a/src/autogluon/bench/eval/evaluation/benchmark_evaluator.py
+++ b/src/autogluon/bench/eval/evaluation/benchmark_evaluator.py
@@ -284,15 +284,17 @@ class BenchmarkEvaluator:
         if f"infer_batch_size_df_{infer_batch_size}" in results_raw.columns:
             # The new infer time column in AMLB Nov 2023 results
             if f"infer_batch_size_file_{infer_batch_size}" in results_raw.columns:
-                results_raw[f"infer_batch_size_df_{infer_batch_size}"] = results_raw[f"infer_batch_size_df_{infer_batch_size}"].fillna(
-                    results_raw[f"infer_batch_size_file_{infer_batch_size}"]
-                )
+                results_raw[f"infer_batch_size_df_{infer_batch_size}"] = results_raw[
+                    f"infer_batch_size_df_{infer_batch_size}"
+                ].fillna(results_raw[f"infer_batch_size_file_{infer_batch_size}"])
             results_raw["time_infer_s"] = results_raw[f"infer_batch_size_df_{infer_batch_size}"].fillna(
                 results_raw["time_infer_s"]
             )
             # FIXME: Divide by infer_batch_size?
             if infer_batch_size != 1:
-                raise AssertionError(f"Debug this logic before working with batch_sizes other than 1 to make sure it is working as intended.")
+                raise AssertionError(
+                    f"Debug this logic before working with batch_sizes other than 1 to make sure it is working as intended."
+                )
         elif f"infer_batch_size_file_{infer_batch_size}" in results_raw.columns:
             # The new infer time column in AMLB Nov 2023 results
             tmp = results_raw[f"infer_batch_size_file_{infer_batch_size}"] / infer_batch_size

--- a/src/autogluon/bench/eval/evaluation/preprocess/preprocess_utils.py
+++ b/src/autogluon/bench/eval/evaluation/preprocess/preprocess_utils.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pandas as pd
 
 from ..constants import *
@@ -36,9 +37,9 @@ def fill_missing_results_with_default(framework_nan_fill: str, frameworks_to_fil
         frameworks_to_fill = [f for f in frameworks_valid if f != frameworks_valid]
 
     results_nan_fill = results_raw[results_raw["framework"] == framework_nan_fill]
-    results_nan_fill = results_nan_fill[["dataset", "fold", "metric_score", "metric_error", "problem_type"]]
-    results_nan_fill["time_train_s"] = 3600
-    results_nan_fill["time_infer_s"] = 1
+    results_nan_fill = results_nan_fill[["dataset", "fold", "metric_error", "problem_type"]]
+    results_nan_fill["time_train_s"] = np.nan
+    results_nan_fill["time_infer_s"] = np.nan
 
     results_raw = results_raw[results_raw["framework"].isin(frameworks_to_fill)]
 

--- a/src/autogluon/bench/eval/scripts/run_evaluation_openml.py
+++ b/src/autogluon/bench/eval/scripts/run_evaluation_openml.py
@@ -256,7 +256,7 @@ def evaluate(
     if len(frameworks_compare_vs_all) == 0:
         frameworks_compare_vs_all = [frameworks_run[0]]
 
-    print("[")
+    print("frameworks = [")
     for i in range(len(frameworks_run)):
         print(f'\t"{frameworks_run[i]}",')
     print("]")

--- a/src/autogluon/bench/eval/scripts/run_generate_clean_openml.py
+++ b/src/autogluon/bench/eval/scripts/run_generate_clean_openml.py
@@ -8,7 +8,16 @@ import pandas as pd
 import typer
 from typing_extensions import Annotated
 
-from autogluon.bench.eval.evaluation.constants import DATASET, FOLD, FRAMEWORK, TIME_TRAIN_S, TIME_INFER_S, METRIC_ERROR, METRIC, PROBLEM_TYPE
+from autogluon.bench.eval.evaluation.constants import (
+    DATASET,
+    FOLD,
+    FRAMEWORK,
+    TIME_TRAIN_S,
+    TIME_INFER_S,
+    METRIC_ERROR,
+    METRIC,
+    PROBLEM_TYPE,
+)
 from autogluon.bench.eval.evaluation.preprocess import preprocess_openml
 from autogluon.common.savers import save_pd
 
@@ -121,7 +130,9 @@ def clean_and_save_results(
     ]
 
     results_raw_columns = list(results_raw.columns)
-    results_raw_columns = [c for c in results_raw_columns if c in minimal_columns] + [c for c in results_raw_columns if c not in minimal_columns]
+    results_raw_columns = [c for c in results_raw_columns if c in minimal_columns] + [
+        c for c in results_raw_columns if c not in minimal_columns
+    ]
     results_raw = results_raw[results_raw_columns]
 
     if save:

--- a/src/autogluon/bench/eval/scripts/run_generate_clean_openml.py
+++ b/src/autogluon/bench/eval/scripts/run_generate_clean_openml.py
@@ -12,11 +12,11 @@ from autogluon.bench.eval.evaluation.constants import (
     DATASET,
     FOLD,
     FRAMEWORK,
-    TIME_TRAIN_S,
-    TIME_INFER_S,
-    METRIC_ERROR,
     METRIC,
+    METRIC_ERROR,
     PROBLEM_TYPE,
+    TIME_INFER_S,
+    TIME_TRAIN_S,
 )
 from autogluon.bench.eval.evaluation.preprocess import preprocess_openml
 from autogluon.common.savers import save_pd


### PR DESCRIPTION
Issue #, if available:

Description of changes:

Updates for evaluation and aggregation based on AG 1.0
- Added support for infer time columns from AMLB Nov 2023 results
- Added support for `paths_extra` to aggregate from multiple result directories (needed for TabRepo)
- Added parquet file format saving and minimal column saving via `save_minimal`
- Minor code cleanup

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.