### PR TITLE
Add `metric` to fill missing logic

### DIFF
--- a/src/autogluon/bench/eval/evaluation/preprocess/preprocess_utils.py
+++ b/src/autogluon/bench/eval/evaluation/preprocess/preprocess_utils.py
@@ -37,7 +37,7 @@ def fill_missing_results_with_default(framework_nan_fill: str, frameworks_to_fil
         frameworks_to_fill = [f for f in frameworks_valid if f != frameworks_valid]
 
     results_nan_fill = results_raw[results_raw["framework"] == framework_nan_fill]
-    results_nan_fill = results_nan_fill[["dataset", "fold", "metric_error", "problem_type"]]
+    results_nan_fill = results_nan_fill[["dataset", "fold", "metric_error", "metric", "problem_type"]]
     results_nan_fill["time_train_s"] = np.nan
     results_nan_fill["time_infer_s"] = np.nan
 


### PR DESCRIPTION
Issue #, if available:

Description of changes:
- Add `metric` to fill missing logic. Now it is correctly set rather than being `NaN`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.