### PR TITLE
Add `worst_nan_fill` logic to evaluation

### DIFF
--- a/src/autogluon/bench/eval/evaluation/preprocess/preprocess_utils.py
+++ b/src/autogluon/bench/eval/evaluation/preprocess/preprocess_utils.py
@@ -24,7 +24,9 @@ def clean_result(result_df, folds_to_keep=None, remove_invalid=True):
     return results_clean_df
 
 
-def fill_missing_results_with_default(framework_nan_fill: str, frameworks_to_fill: list, results_raw: pd.DataFrame) -> pd.DataFrame:
+def fill_missing_results_with_default(
+    framework_nan_fill: str, frameworks_to_fill: list, results_raw: pd.DataFrame
+) -> pd.DataFrame:
     """
     Fill missing results with the result of `framework_nan_fill` framework.
     """
@@ -45,7 +47,9 @@ def fill_missing_results_with_default(framework_nan_fill: str, frameworks_to_fil
     return _fill_missing(results_nan_fill=results_nan_fill, results_raw=results_raw)
 
 
-def fill_missing_results_with_worst(frameworks_to_consider: list, frameworks_to_fill: list, results_raw: pd.DataFrame) -> pd.DataFrame:
+def fill_missing_results_with_worst(
+    frameworks_to_consider: list, frameworks_to_fill: list, results_raw: pd.DataFrame
+) -> pd.DataFrame:
     if frameworks_to_consider is None:
         frameworks_to_consider = list(results_raw["framework"].unique())
     if frameworks_to_fill is None:
@@ -53,7 +57,9 @@ def fill_missing_results_with_worst(frameworks_to_consider: list, frameworks_to_
     results_to_consider = results_raw[results_raw[FRAMEWORK].isin(frameworks_to_consider)]
     task_metric_problem_type = results_to_consider[["dataset", "fold", "metric", "problem_type"]].drop_duplicates()
 
-    worst_result_per_task = results_to_consider[[DATASET, FOLD, METRIC_ERROR]].groupby([DATASET, FOLD])[METRIC_ERROR].max()
+    worst_result_per_task = (
+        results_to_consider[[DATASET, FOLD, METRIC_ERROR]].groupby([DATASET, FOLD])[METRIC_ERROR].max()
+    )
     worst_result_per_task = worst_result_per_task.to_frame().reset_index()
 
     results_nan_fill = pd.merge(task_metric_problem_type, worst_result_per_task)

--- a/src/autogluon/bench/eval/scripts/run_evaluation_openml.py
+++ b/src/autogluon/bench/eval/scripts/run_evaluation_openml.py
@@ -116,6 +116,7 @@ def evaluate(
     output_suffix: str | None = None,
     frameworks_rename: dict | None = None,
     framework_nan_fill: str | None = None,
+    worst_nan_fill: bool = False,
     problem_type: List[str] | str | None = None,
     folds_to_keep: List[int] | None = None,
     compute_z_score: bool = True,
@@ -235,6 +236,7 @@ def evaluate(
         output_suffix=output_suffix,
         use_tid_as_dataset_name=use_tid_as_dataset_name,
         framework_nan_fill=framework_nan_fill,
+        worst_nan_fill=worst_nan_fill,
         filter_errors=filter_errors,
         task_metadata=task_metadata,
     )


### PR DESCRIPTION
Issue #, if available:

Description of changes:

Add `worst_nan_fill` logic to evaluation
- When True, this logic allows to fill missing results with the worst result observed of any framework on a given task.
- Works as an alternative to `framework_nan_fill`, without needing to specify a specific framework to base the filling on.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.