### PR TITLE
Enhance logging and assertions, prevent multiple eval metrics per dataset

### DIFF
--- a/src/autogluon/bench/eval/evaluation/evaluate_results.py
+++ b/src/autogluon/bench/eval/evaluation/evaluate_results.py
@@ -139,6 +139,13 @@ def evaluate(
         print("num_folds:", num_folds)
         print("errors:", errors)
         print("################################################")
+
+    missing_frameworks = [f for f in frameworks_compare_vs_all if f not in total_frameworks]
+    if missing_frameworks:
+        raise AssertionError(
+            f"Missing specified comparison frameworks: {missing_frameworks}\n"
+            f"\tValid frameworks: {list(total_frameworks)}"
+        )
     for framework in total_frameworks:
         results_framework = results_raw[results_raw[FRAMEWORK] == framework]
         num_rows_framework = len(results_framework)

--- a/src/autogluon/bench/eval/evaluation/preprocess/preprocess_openml.py
+++ b/src/autogluon/bench/eval/evaluation/preprocess/preprocess_openml.py
@@ -16,9 +16,9 @@ def _update_framework_name(name: str, parent: str, name_suffix_1: str, name_suff
     else:
         name_new = name
     if name_suffix_1:
-        name_new = name_new + "_" + name_suffix_1
+        name_new = name_new + "_" + str(name_suffix_1)
     if name_suffix_2:
-        name_new = name_new + "_" + name_suffix_2
+        name_new = name_new + "_" + str(name_suffix_2)
     if is_valid_parent:
         return name, name_new
     else:
@@ -111,10 +111,11 @@ def preprocess_openml_input(
         "f1_micro",
         "quadratic_kappa",
     ]
-    raw_input[METRIC_ERROR] = [
-        1 - score if metric in metric_list else float(score) if metric == "rmse" else -score
-        for score, metric in zip(raw_input[METRIC_SCORE], raw_input["metric"])
-    ]
+    if METRIC_ERROR not in raw_input:
+        raw_input[METRIC_ERROR] = [
+            1 - score if metric in metric_list else float(score) if metric == "rmse" else -score
+            for score, metric in zip(raw_input[METRIC_SCORE], raw_input["metric"])
+        ]
 
     if raw_input[METRIC_ERROR].min() < 0:
         eps = -1 / 1e8

--- a/src/autogluon/bench/eval/evaluation/preprocess/preprocess_openml.py
+++ b/src/autogluon/bench/eval/evaluation/preprocess/preprocess_openml.py
@@ -147,9 +147,9 @@ def preprocess_openml_input(
     if "tid" in cleaned_input:
         """
         Update tid to the new ones in case the runs are old
-    
+
         Name                | oldtid | newtid
-    
+
         KDDCup09-Upselling  | 360115 | 360975
         MIP-2016-regression | 359947 | 360945
         QSAR-TID-10980      |  14097 | 360933

--- a/src/autogluon/bench/eval/evaluation/preprocess/preprocess_openml.py
+++ b/src/autogluon/bench/eval/evaluation/preprocess/preprocess_openml.py
@@ -138,40 +138,35 @@ def preprocess_openml_input(
 
     cleaned_input = preprocess_utils.clean_result(raw_input, folds_to_keep=folds_to_keep, remove_invalid=False)
 
-    cleaned_input["tid"] = [
-        int(part) for x in cleaned_input["id"] for part in re.split(r"[/_]", x)[-1:] if part.isdigit()
-    ]
+    if "tid" not in cleaned_input:
+        if "id" in cleaned_input:
+            cleaned_input["tid"] = [
+                int(part) for x in cleaned_input["id"] for part in re.split(r"[/_]", x)[-1:] if part.isdigit()
+            ]
 
-    """
-    Update tid to the new ones in case the runs are old
-
-    Name                | oldtid | newtid
-
-    KDDCup09-Upselling  | 360115 | 360975
-    MIP-2016-regression | 359947 | 360945
-    QSAR-TID-10980      |  14097 | 360933
-    QSAR-TID-11         |  13854 | 360932
-    """
-    cleaned_input["tid"] = (
-        cleaned_input["tid"]
-        .map(
-            {
-                360115: 360975,
-                359947: 360945,
-                14097: 360933,
-                13854: 360932,
-            }
+    if "tid" in cleaned_input:
+        """
+        Update tid to the new ones in case the runs are old
+    
+        Name                | oldtid | newtid
+    
+        KDDCup09-Upselling  | 360115 | 360975
+        MIP-2016-regression | 359947 | 360945
+        QSAR-TID-10980      |  14097 | 360933
+        QSAR-TID-11         |  13854 | 360932
+        """
+        cleaned_input["tid"] = (
+            cleaned_input["tid"]
+            .map(
+                {
+                    360115: 360975,
+                    359947: 360945,
+                    14097: 360933,
+                    13854: 360932,
+                }
+            )
+            .fillna(cleaned_input["tid"])
         )
-        .fillna(cleaned_input["tid"])
-    )
-
-    # add_if_missing = [
-    #     TIME_TRAIN_S,
-    #     TIME_INFER_S,
-    # ]
-    # add_missing = [c for c in add_if_missing if c not in cleaned_input.columns]
-    # if add_missing:
-    #     cleaned_input[add_missing] = np.nan
 
     required_output_columns = [
         DATASET,
@@ -182,7 +177,6 @@ def preprocess_openml_input(
         PROBLEM_TYPE,
         TIME_TRAIN_S,
         TIME_INFER_S,
-        "tid",
     ]
     actual_columns = list(cleaned_input.columns)
     missing_columns = [c for c in required_output_columns if c not in actual_columns]

--- a/src/autogluon/bench/eval/evaluation/preprocess/preprocess_utils.py
+++ b/src/autogluon/bench/eval/evaluation/preprocess/preprocess_utils.py
@@ -130,7 +130,7 @@ def assert_unique_dataset_tid_pairs(results_raw: pd.DataFrame):
 
     """
     assert DATASET in results_raw.columns, f"{DATASET} must be a column in results_raw"
-    assert "tid" in results_raw.columns, f"tid must be a column in results_raw"
+    assert "tid" in results_raw.columns, f"tid must be a column in results_raw when `use_tid_as_dataset_name=True`"
     results_unique_dataset_tid_pairs = results_raw[[DATASET, "tid"]].value_counts().reset_index(drop=False)
     unique_datasets = results_raw[DATASET].unique()
     unique_tids = results_raw["tid"].unique()


### PR DESCRIPTION
Issue #, if available:

Description of changes:
- Enhance logging and assertions
- Prevent multiple eval metrics per dataset
- Make tid optional during preprocessing

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.