### PR TITLE
Fix path issue in AG-Bench

### DIFF
--- a/src/autogluon/bench/runbenchmark.py
+++ b/src/autogluon/bench/runbenchmark.py
@@ -131,24 +131,24 @@ def run_benchmark(
         if module_name == "multimodal":
             upload_path = [
                 configs.get("mode", None),
-                module_kwargs["run_kwargs"].get(["dataset_name"], None),
-                module_kwargs["run_kwargs"].get(["constraint"], None),
+                module_kwargs["run_kwargs"].get("dataset_name", None),
+                module_kwargs["run_kwargs"].get("constraint", None),
                 framework_name,
             ]
         elif module_name == "tabular":
             upload_path = [
                 configs.get("mode", None),
-                module_kwargs["run_kwargs"].get(["benchmark"], None),
-                module_kwargs["run_kwargs"].get(["constraint"], None),
-                module_kwargs["run_kwargs"].get(["task"], None),
-                module_kwargs["run_kwargs"].get(["fold"], None),
+                module_kwargs["run_kwargs"].get("benchmark", None),
+                module_kwargs["run_kwargs"].get("constraint", None),
+                module_kwargs["run_kwargs"].get("task", None),
+                module_kwargs["run_kwargs"].get("fold", None),
                 framework_name,
             ]
         else:  # ToDo: Re-order fields for specific module name if required
             upload_path = [
                 configs.get("mode", None),
-                module_kwargs["run_kwargs"].get(["dataset_name"], None),
-                module_kwargs["run_kwargs"].get(["constraint"], None),
+                module_kwargs["run_kwargs"].get("dataset_name", None),
+                module_kwargs["run_kwargs"].get("constraint", None),
                 framework_name,
             ]
 

--- a/src/autogluon/bench/runbenchmark.py
+++ b/src/autogluon/bench/runbenchmark.py
@@ -93,11 +93,7 @@ def _get_benchmark_name(configs: dict) -> str:
 
 
 def run_benchmark(
-    benchmark_name: str,
-    benchmark_dir: str,
-    configs: dict,
-    benchmark_dir_s3: str = None,
-    skip_setup: str = False,
+    benchmark_name: str, benchmark_dir: str, configs: dict, benchmark_dir_s3: str = None, skip_setup: str = False
 ):
     """Runs a benchmark based on the provided configuration options.
 
@@ -134,23 +130,23 @@ def run_benchmark(
         upload_path = []
         if module_name == "multimodal":
             upload_path = [
-                framework_name, 
-                module_kwargs["run_kwargs"]["dataset_name"], 
-                module_kwargs["run_kwargs"]["constraint"], 
-                configs.get("mode", None)
+                framework_name,
+                module_kwargs["run_kwargs"]["dataset_name"],
+                module_kwargs["run_kwargs"]["constraint"],
+                configs.get("mode", None),
             ]
         else:
             upload_path = [
-                framework_name, 
-                module_kwargs["run_kwargs"]["benchmark"], 
-                module_kwargs["run_kwargs"]["task"], 
-                module_kwargs["run_kwargs"]["constraint"], 
-                configs.get("mode", None), 
-                module_kwargs["run_kwargs"]["fold"]
+                framework_name,
+                module_kwargs["run_kwargs"]["benchmark"],
+                module_kwargs["run_kwargs"]["task"],
+                module_kwargs["run_kwargs"]["constraint"],
+                configs.get("mode", None),
+                module_kwargs["run_kwargs"]["fold"],
             ]
-            
-        upload_path_str = '.'.join(str(part) for part in upload_path)
-        benchmark_dir_s3 += f"/{upload_path_str}" 
+
+        upload_path_str = ".".join(str(part) for part in upload_path)
+        benchmark_dir_s3 += f"/{upload_path_str}"
         benchmark.upload_metrics(s3_bucket=configs["METRICS_BUCKET"], s3_dir=benchmark_dir_s3)
 
 
@@ -494,9 +490,7 @@ def run(
 
             response = invoke_lambda(configs=infra_configs, config_file=config_s3_path)
 
-            job_configs = {
-                "job_configs": response,
-            }
+            job_configs = {"job_configs": response}
             aws_configs = {**infra_configs, **job_configs}
             logger.info(f"Saving infra configs and submitted job configs under {benchmark_dir}.")
             aws_config_path = _dump_configs(

--- a/src/autogluon/bench/runbenchmark.py
+++ b/src/autogluon/bench/runbenchmark.py
@@ -130,6 +130,18 @@ def run_benchmark(
     _dump_configs(benchmark_dir=benchmark.metrics_dir, configs=configs, file_name="configs.yaml")
 
     if configs.get("METRICS_BUCKET", None):
+        framework_name = module_kwargs["run_kwargs"]["framework"].split(":")[0]
+        upload_path = []
+        if module_name == "multimodal":
+            upload_path = [framework_name, module_kwargs["run_kwargs"]["dataset_name"], 
+                           module_kwargs["run_kwargs"]["constraint"], configs.get("mode", None)]
+        else:
+            upload_path = [framework_name, module_kwargs["run_kwargs"]["benchmark"], 
+                           module_kwargs["run_kwargs"]["task"], module_kwargs["run_kwargs"]["constraint"], 
+                           configs.get("mode", None), module_kwargs["run_kwargs"]["fold"]]
+            
+        upload_path_str = '.'.join(str(part) for part in upload_path)
+        benchmark_dir_s3 += f"/{upload_path_str}" 
         benchmark.upload_metrics(s3_bucket=configs["METRICS_BUCKET"], s3_dir=benchmark_dir_s3)
 
 

--- a/src/autogluon/bench/runbenchmark.py
+++ b/src/autogluon/bench/runbenchmark.py
@@ -130,7 +130,7 @@ def run_benchmark(
             framework_name = module_kwargs["run_kwargs"]["framework"].split(":")[0]
         else:
             framework_name = module_kwargs["run_kwargs"]["framework"]
-            
+
         upload_path = []
         if module_name == "multimodal":
             upload_path = [

--- a/src/autogluon/bench/runbenchmark.py
+++ b/src/autogluon/bench/runbenchmark.py
@@ -126,34 +126,30 @@ def run_benchmark(
     _dump_configs(benchmark_dir=benchmark.metrics_dir, configs=configs, file_name="configs.yaml")
 
     if configs.get("METRICS_BUCKET", None):
-        if ":" in module_kwargs["run_kwargs"]["framework"]:
-            framework_name = module_kwargs["run_kwargs"]["framework"].split(":")[0]
-        else:
-            framework_name = module_kwargs["run_kwargs"]["framework"]
-
+        framework_name = module_kwargs["run_kwargs"]["framework"].split(":")[0]
         upload_path = []
         if module_name == "multimodal":
             upload_path = [
-                framework_name,
+                configs.get("mode", None),
                 module_kwargs["run_kwargs"].get(["dataset_name"], None),
                 module_kwargs["run_kwargs"].get(["constraint"], None),
-                configs.get("mode", None),
+                framework_name,
             ]
         elif module_name == "tabular":
             upload_path = [
-                framework_name,
-                module_kwargs["run_kwargs"].get(["benchmark"], None),
-                module_kwargs["run_kwargs"].get(["task"], None),
-                module_kwargs["run_kwargs"].get(["constraint"], None),
                 configs.get("mode", None),
+                module_kwargs["run_kwargs"].get(["benchmark"], None),
+                module_kwargs["run_kwargs"].get(["constraint"], None),
+                module_kwargs["run_kwargs"].get(["task"], None),
                 module_kwargs["run_kwargs"].get(["fold"], None),
-            ]
-        else:
-            upload_path = [
                 framework_name,
+            ]
+        else:  # ToDo: Re-order fields for specific module name if required
+            upload_path = [
+                configs.get("mode", None),
                 module_kwargs["run_kwargs"].get(["dataset_name"], None),
                 module_kwargs["run_kwargs"].get(["constraint"], None),
-                configs.get("mode", None),
+                framework_name,
             ]
 
         upload_path_str = ".".join(str(part) for part in upload_path)

--- a/src/autogluon/bench/runbenchmark.py
+++ b/src/autogluon/bench/runbenchmark.py
@@ -133,12 +133,21 @@ def run_benchmark(
         framework_name = module_kwargs["run_kwargs"]["framework"].split(":")[0]
         upload_path = []
         if module_name == "multimodal":
-            upload_path = [framework_name, module_kwargs["run_kwargs"]["dataset_name"], 
-                           module_kwargs["run_kwargs"]["constraint"], configs.get("mode", None)]
+            upload_path = [
+                framework_name, 
+                module_kwargs["run_kwargs"]["dataset_name"], 
+                module_kwargs["run_kwargs"]["constraint"], 
+                configs.get("mode", None)
+            ]
         else:
-            upload_path = [framework_name, module_kwargs["run_kwargs"]["benchmark"], 
-                           module_kwargs["run_kwargs"]["task"], module_kwargs["run_kwargs"]["constraint"], 
-                           configs.get("mode", None), module_kwargs["run_kwargs"]["fold"]]
+            upload_path = [
+                framework_name, 
+                module_kwargs["run_kwargs"]["benchmark"], 
+                module_kwargs["run_kwargs"]["task"], 
+                module_kwargs["run_kwargs"]["constraint"], 
+                configs.get("mode", None), 
+                module_kwargs["run_kwargs"]["fold"]
+            ]
             
         upload_path_str = '.'.join(str(part) for part in upload_path)
         benchmark_dir_s3 += f"/{upload_path_str}" 

--- a/src/autogluon/bench/runbenchmark.py
+++ b/src/autogluon/bench/runbenchmark.py
@@ -126,23 +126,34 @@ def run_benchmark(
     _dump_configs(benchmark_dir=benchmark.metrics_dir, configs=configs, file_name="configs.yaml")
 
     if configs.get("METRICS_BUCKET", None):
-        framework_name = module_kwargs["run_kwargs"]["framework"].split(":")[0]
+        if ":" in module_kwargs["run_kwargs"]["framework"]:
+            framework_name = module_kwargs["run_kwargs"]["framework"].split(":")[0]
+        else:
+            framework_name = module_kwargs["run_kwargs"]["framework"]
+            
         upload_path = []
         if module_name == "multimodal":
             upload_path = [
                 framework_name,
-                module_kwargs["run_kwargs"]["dataset_name"],
-                module_kwargs["run_kwargs"]["constraint"],
+                module_kwargs["run_kwargs"].get(["dataset_name"], None),
+                module_kwargs["run_kwargs"].get(["constraint"], None),
                 configs.get("mode", None),
+            ]
+        elif module_name == "tabular":
+            upload_path = [
+                framework_name,
+                module_kwargs["run_kwargs"].get(["benchmark"], None),
+                module_kwargs["run_kwargs"].get(["task"], None),
+                module_kwargs["run_kwargs"].get(["constraint"], None),
+                configs.get("mode", None),
+                module_kwargs["run_kwargs"].get(["fold"], None),
             ]
         else:
             upload_path = [
                 framework_name,
-                module_kwargs["run_kwargs"]["benchmark"],
-                module_kwargs["run_kwargs"]["task"],
-                module_kwargs["run_kwargs"]["constraint"],
+                module_kwargs["run_kwargs"].get(["dataset_name"], None),
+                module_kwargs["run_kwargs"].get(["constraint"], None),
                 configs.get("mode", None),
-                module_kwargs["run_kwargs"]["fold"],
             ]
 
         upload_path_str = ".".join(str(part) for part in upload_path)

--- a/src/autogluon/bench/runbenchmark.py
+++ b/src/autogluon/bench/runbenchmark.py
@@ -135,7 +135,7 @@ def run_benchmark(
                 module_kwargs["run_kwargs"].get("constraint", None),
                 framework_name,
             ]
-        elif module_name == "tabular":
+        elif module_name == "tabular" or module_name == "timeseries":
             upload_path = [
                 configs.get("mode", None),
                 module_kwargs["run_kwargs"].get("benchmark", None),

--- a/tests/unittests/benchmark/test_runbenchmarks.py
+++ b/tests/unittests/benchmark/test_runbenchmarks.py
@@ -303,7 +303,7 @@ def test_run_benchmark(mocker):
 
     setup_mock.assert_called_once_with()
     run_mock.assert_called_once_with(framework="AutoGluon:stable")
-    upload_metrics_mock.assert_called_once_with(s3_bucket=configs["METRICS_BUCKET"], s3_dir="s3_dir")
+    upload_metrics_mock.assert_called_once_with(s3_bucket=configs["METRICS_BUCKET"], s3_dir="s3_dir/None.None.None.None.None.AutoGluon")
 
 
 def test_run_benchmark_skip_setup(mocker):
@@ -330,7 +330,7 @@ def test_run_benchmark_skip_setup(mocker):
 
     setup_mock.assert_not_called()
     run_mock.assert_called_once_with(framework="AutoGluon:stable")
-    upload_metrics_mock.assert_called_once_with(s3_bucket=configs["METRICS_BUCKET"], s3_dir="s3_dir")
+    upload_metrics_mock.assert_called_once_with(s3_bucket=configs["METRICS_BUCKET"], s3_dir="s3_dir/None.None.None.None.None.AutoGluon")
 
 
 def test_get_job_status_with_config_file(mocker, tmp_path):
@@ -440,4 +440,4 @@ def test_run_benchmark_timeseries(mocker):
 
     setup_mock.assert_called_once_with()
     run_mock.assert_called_once_with(framework="AutoGluon:stable")
-    upload_metrics_mock.assert_called_once_with(s3_bucket=configs["METRICS_BUCKET"], s3_dir="s3_dir")
+    upload_metrics_mock.assert_called_once_with(s3_bucket=configs["METRICS_BUCKET"], s3_dir="s3_dir/None.None.None.AutoGluon")

--- a/tests/unittests/benchmark/test_runbenchmarks.py
+++ b/tests/unittests/benchmark/test_runbenchmarks.py
@@ -354,10 +354,9 @@ def test_run_benchmark(mocker):
     configs = {
         "module": "tabular",
         "METRICS_BUCKET": "test_bucket",
-        "framework": "AutoGluon:stable",
     }
 
-    mocker.patch("autogluon.bench.runbenchmark.get_kwargs", return_value={"setup_kwargs": {}, "run_kwargs": {}})
+    mocker.patch("autogluon.bench.runbenchmark.get_kwargs", return_value={"setup_kwargs": {}, "run_kwargs": {"framework": "AutoGluon:stable"}})
     setup_mock = mocker.patch("autogluon.bench.runbenchmark.TabularBenchmark.setup")
     run_mock = mocker.patch("autogluon.bench.runbenchmark.TabularBenchmark.run")
     upload_metrics_mock = mocker.patch("autogluon.bench.runbenchmark.TabularBenchmark.upload_metrics")
@@ -378,10 +377,9 @@ def test_run_benchmark_skip_setup(mocker):
     configs = {
         "module": "tabular",
         "METRICS_BUCKET": "test_bucket",
-        "framework": "AutoGluon:stable",
     }
 
-    mocker.patch("autogluon.bench.runbenchmark.get_kwargs", return_value={"setup_kwargs": {}, "run_kwargs": {}})
+    mocker.patch("autogluon.bench.runbenchmark.get_kwargs", return_value={"setup_kwargs": {}, "run_kwargs": {"framework": "AutoGluon:stable"}})
     setup_mock = mocker.patch("autogluon.bench.runbenchmark.TabularBenchmark.setup")
     run_mock = mocker.patch("autogluon.bench.runbenchmark.TabularBenchmark.run")
     upload_metrics_mock = mocker.patch("autogluon.bench.runbenchmark.TabularBenchmark.upload_metrics")
@@ -498,10 +496,9 @@ def test_run_benchmark_timeseries(mocker):
     configs = {
         "module": "timeseries",
         "METRICS_BUCKET": "test_bucket",
-        "framework": "AutoGluon:stable",
     }
 
-    mocker.patch("autogluon.bench.runbenchmark.get_kwargs", return_value={"setup_kwargs": {}, "run_kwargs": {}})
+    mocker.patch("autogluon.bench.runbenchmark.get_kwargs", return_value={"setup_kwargs": {}, "run_kwargs": {"framework": "AutoGluon:stable"}})
     setup_mock = mocker.patch("autogluon.bench.runbenchmark.TimeSeriesBenchmark.setup")
     run_mock = mocker.patch("autogluon.bench.runbenchmark.TimeSeriesBenchmark.run")
     upload_metrics_mock = mocker.patch("autogluon.bench.runbenchmark.TimeSeriesBenchmark.upload_metrics")

--- a/tests/unittests/benchmark/test_runbenchmarks.py
+++ b/tests/unittests/benchmark/test_runbenchmarks.py
@@ -303,7 +303,9 @@ def test_run_benchmark(mocker):
 
     setup_mock.assert_called_once_with()
     run_mock.assert_called_once_with(framework="AutoGluon:stable")
-    upload_metrics_mock.assert_called_once_with(s3_bucket=configs["METRICS_BUCKET"], s3_dir="s3_dir/None.None.None.None.None.AutoGluon")
+    upload_metrics_mock.assert_called_once_with(
+        s3_bucket=configs["METRICS_BUCKET"], s3_dir="s3_dir/None.None.None.None.None.AutoGluon"
+    )
 
 
 def test_run_benchmark_skip_setup(mocker):
@@ -330,7 +332,9 @@ def test_run_benchmark_skip_setup(mocker):
 
     setup_mock.assert_not_called()
     run_mock.assert_called_once_with(framework="AutoGluon:stable")
-    upload_metrics_mock.assert_called_once_with(s3_bucket=configs["METRICS_BUCKET"], s3_dir="s3_dir/None.None.None.None.None.AutoGluon")
+    upload_metrics_mock.assert_called_once_with(
+        s3_bucket=configs["METRICS_BUCKET"], s3_dir="s3_dir/None.None.None.None.None.AutoGluon"
+    )
 
 
 def test_get_job_status_with_config_file(mocker, tmp_path):
@@ -440,4 +444,6 @@ def test_run_benchmark_timeseries(mocker):
 
     setup_mock.assert_called_once_with()
     run_mock.assert_called_once_with(framework="AutoGluon:stable")
-    upload_metrics_mock.assert_called_once_with(s3_bucket=configs["METRICS_BUCKET"], s3_dir="s3_dir/None.None.None.AutoGluon")
+    upload_metrics_mock.assert_called_once_with(
+        s3_bucket=configs["METRICS_BUCKET"], s3_dir="s3_dir/None.None.None.AutoGluon"
+    )

--- a/tests/unittests/benchmark/test_runbenchmarks.py
+++ b/tests/unittests/benchmark/test_runbenchmarks.py
@@ -354,6 +354,7 @@ def test_run_benchmark(mocker):
     configs = {
         "module": "tabular",
         "METRICS_BUCKET": "test_bucket",
+        "framework": "AutoGluon:stable",
     }
 
     mocker.patch("autogluon.bench.runbenchmark.get_kwargs", return_value={"setup_kwargs": {}, "run_kwargs": {}})
@@ -377,6 +378,7 @@ def test_run_benchmark_skip_setup(mocker):
     configs = {
         "module": "tabular",
         "METRICS_BUCKET": "test_bucket",
+        "framework": "AutoGluon:stable",
     }
 
     mocker.patch("autogluon.bench.runbenchmark.get_kwargs", return_value={"setup_kwargs": {}, "run_kwargs": {}})
@@ -496,6 +498,7 @@ def test_run_benchmark_timeseries(mocker):
     configs = {
         "module": "timeseries",
         "METRICS_BUCKET": "test_bucket",
+        "framework": "AutoGluon:stable",
     }
 
     mocker.patch("autogluon.bench.runbenchmark.get_kwargs", return_value={"setup_kwargs": {}, "run_kwargs": {}})

--- a/tests/unittests/benchmark/test_runbenchmarks.py
+++ b/tests/unittests/benchmark/test_runbenchmarks.py
@@ -286,11 +286,20 @@ def test_run_local_mode(mocker, tmp_path):
 def test_run_benchmark(mocker):
     benchmark_name = "test_benchmark"
     benchmark_dir = "test_dir"
-    configs = {"module": "tabular", "METRICS_BUCKET": "test_bucket"}
+    configs = {"module": "tabular", "METRICS_BUCKET": "test_bucket", "mode": "local"}
 
     mocker.patch(
         "autogluon.bench.runbenchmark.get_kwargs",
-        return_value={"setup_kwargs": {}, "run_kwargs": {"framework": "AutoGluon:stable"}},
+        return_value={
+            "setup_kwargs": {},
+            "run_kwargs": {
+                "framework": "AutoGluon:stable",
+                "benchmark": "toy",
+                "constraint": "test_constraint",
+                "task": "dummy_task",
+                "fold": 0,
+            },
+        },
     )
     setup_mock = mocker.patch("autogluon.bench.runbenchmark.TabularBenchmark.setup")
     run_mock = mocker.patch("autogluon.bench.runbenchmark.TabularBenchmark.run")
@@ -302,20 +311,31 @@ def test_run_benchmark(mocker):
     )
 
     setup_mock.assert_called_once_with()
-    run_mock.assert_called_once_with(framework="AutoGluon:stable")
+    run_mock.assert_called_once_with(
+        framework="AutoGluon:stable", benchmark="toy", constraint="test_constraint", task="dummy_task", fold=0
+    )
     upload_metrics_mock.assert_called_once_with(
-        s3_bucket=configs["METRICS_BUCKET"], s3_dir="s3_dir/None.None.None.None.None.AutoGluon"
+        s3_bucket=configs["METRICS_BUCKET"], s3_dir="s3_dir/local.toy.test_constraint.dummy_task.0.AutoGluon"
     )
 
 
 def test_run_benchmark_skip_setup(mocker):
     benchmark_name = "test_benchmark"
     benchmark_dir = "test_dir"
-    configs = {"module": "tabular", "METRICS_BUCKET": "test_bucket"}
+    configs = {"module": "tabular", "METRICS_BUCKET": "test_bucket", "mode": "local"}
 
     mocker.patch(
         "autogluon.bench.runbenchmark.get_kwargs",
-        return_value={"setup_kwargs": {}, "run_kwargs": {"framework": "AutoGluon:stable"}},
+        return_value={
+            "setup_kwargs": {},
+            "run_kwargs": {
+                "framework": "AutoGluon:stable",
+                "benchmark": "toy",
+                "constraint": "test_constraint",
+                "task": "dummy_task",
+                "fold": 0,
+            },
+        },
     )
     setup_mock = mocker.patch("autogluon.bench.runbenchmark.TabularBenchmark.setup")
     run_mock = mocker.patch("autogluon.bench.runbenchmark.TabularBenchmark.run")
@@ -331,9 +351,11 @@ def test_run_benchmark_skip_setup(mocker):
     )
 
     setup_mock.assert_not_called()
-    run_mock.assert_called_once_with(framework="AutoGluon:stable")
+    run_mock.assert_called_once_with(
+        framework="AutoGluon:stable", benchmark="toy", constraint="test_constraint", task="dummy_task", fold=0
+    )
     upload_metrics_mock.assert_called_once_with(
-        s3_bucket=configs["METRICS_BUCKET"], s3_dir="s3_dir/None.None.None.None.None.AutoGluon"
+        s3_bucket=configs["METRICS_BUCKET"], s3_dir="s3_dir/local.toy.test_constraint.dummy_task.0.AutoGluon"
     )
 
 
@@ -427,11 +449,20 @@ def test_run_aws_timeseries_user_dir(mocker, tmp_path):
 def test_run_benchmark_timeseries(mocker):
     benchmark_name = "test_benchmark"
     benchmark_dir = "test_dir"
-    configs = {"module": "timeseries", "METRICS_BUCKET": "test_bucket"}
+    configs = {"module": "timeseries", "METRICS_BUCKET": "test_bucket", "mode": "local"}
 
     mocker.patch(
         "autogluon.bench.runbenchmark.get_kwargs",
-        return_value={"setup_kwargs": {}, "run_kwargs": {"framework": "AutoGluon:stable"}},
+        return_value={
+            "setup_kwargs": {},
+            "run_kwargs": {
+                "framework": "AutoGluon:stable",
+                "benchmark": "toy",
+                "constraint": "test_constraint",
+                "task": "dummy_task",
+                "fold": 0,
+            },
+        },
     )
     setup_mock = mocker.patch("autogluon.bench.runbenchmark.TimeSeriesBenchmark.setup")
     run_mock = mocker.patch("autogluon.bench.runbenchmark.TimeSeriesBenchmark.run")
@@ -443,7 +474,9 @@ def test_run_benchmark_timeseries(mocker):
     )
 
     setup_mock.assert_called_once_with()
-    run_mock.assert_called_once_with(framework="AutoGluon:stable")
+    run_mock.assert_called_once_with(
+        framework="AutoGluon:stable", benchmark="toy", constraint="test_constraint", task="dummy_task", fold=0
+    )
     upload_metrics_mock.assert_called_once_with(
-        s3_bucket=configs["METRICS_BUCKET"], s3_dir="s3_dir/None.None.None.AutoGluon"
+        s3_bucket=configs["METRICS_BUCKET"], s3_dir="s3_dir/local.toy.test_constraint.dummy_task.0.AutoGluon"
     )

--- a/tests/unittests/benchmark/test_runbenchmarks.py
+++ b/tests/unittests/benchmark/test_runbenchmarks.py
@@ -13,13 +13,8 @@ def setup_mock(
     config_file.touch()
     # mock_open = mocker.patch("builtins.open", new_callable=mocker.mock_open)
     mocker.patch("re.search", return_value=False)
-    cdk_context = {
-        "METRICS_BUCKET": "test_bucket",
-    }
-    job_configs = {
-        "job_id_1": "config_spit_1",
-        "job_id_2": "config_spit_2",
-    }
+    cdk_context = {"METRICS_BUCKET": "test_bucket"}
+    job_configs = {"job_id_1": "config_spit_1", "job_id_2": "config_spit_2"}
 
     infra_configs = {
         "STATIC_RESOURCE_STACK_NAME": "test_static_stack",
@@ -44,12 +39,7 @@ def setup_mock(
             "custom_metrics": custom_metrics,
         }
 
-    yaml_value = {
-        "mode": "aws",
-        "module": module,
-        "cdk_context": cdk_context,
-        "job_configs": job_configs,
-    }
+    yaml_value = {"mode": "aws", "module": module, "cdk_context": cdk_context, "job_configs": job_configs}
     yaml_value.update(infra_configs)
     yaml_value.update(module_configs)
 
@@ -98,16 +88,10 @@ def setup_mock(
 
 def test_get_kwargs_multimodal():
     module = "multimodal"
-    configs = {
-        "framework": "AutoGluon_stable",
-        "dataset_name": "dataset",
-    }
+    configs = {"framework": "AutoGluon_stable", "dataset_name": "dataset"}
 
     expected_result = {
-        "setup_kwargs": {
-            "git_uri": "https://github.com/autogluon/autogluon.git",
-            "git_branch": "stable",
-        },
+        "setup_kwargs": {"git_uri": "https://github.com/autogluon/autogluon.git", "git_branch": "stable"},
         "run_kwargs": {
             "dataset_name": "dataset",
             "framework": "AutoGluon_stable",
@@ -178,13 +162,7 @@ def test_invoke_lambda(mocker):
 def test_run_aws_mode(mocker, tmp_path):
     setup = setup_mock(mocker, tmp_path)
 
-    run(
-        setup["config_file"],
-        remove_resources=False,
-        wait=False,
-        skip_setup=True,
-        save_hardware_metrics=False,
-    )
+    run(setup["config_file"], remove_resources=False, wait=False, skip_setup=True, save_hardware_metrics=False)
 
     setup["mock_deploy_stack"].assert_called_once_with(custom_configs=setup["custom_configs"])
     setup["mock_upload_to_s3"].assert_called_once_with(
@@ -199,13 +177,7 @@ def test_run_aws_mode(mocker, tmp_path):
 def test_run_aws_mode_remove_resources(mocker, tmp_path):
     setup = setup_mock(mocker, tmp_path)
 
-    run(
-        setup["config_file"],
-        remove_resources=True,
-        wait=False,
-        skip_setup=True,
-        save_hardware_metrics=False,
-    )
+    run(setup["config_file"], remove_resources=True, wait=False, skip_setup=True, save_hardware_metrics=False)
 
     setup["mock_deploy_stack"].assert_called_once_with(custom_configs=setup["custom_configs"])
     setup["mock_upload_to_s3"].assert_called_once_with(
@@ -226,13 +198,7 @@ def test_run_aws_mode_remove_resources(mocker, tmp_path):
 def test_run_aws_mode_wait(mocker, tmp_path):
     setup = setup_mock(mocker, tmp_path)
 
-    run(
-        setup["config_file"],
-        remove_resources=False,
-        wait=True,
-        skip_setup=True,
-        save_hardware_metrics=False,
-    )
+    run(setup["config_file"], remove_resources=False, wait=True, skip_setup=True, save_hardware_metrics=False)
 
     setup["mock_deploy_stack"].assert_called_once_with(custom_configs=setup["custom_configs"])
     setup["mock_upload_to_s3"].assert_called_once_with(
@@ -249,13 +215,7 @@ def test_run_aws_tabular_user_dir(mocker, tmp_path):
     temp_dir_mock = mocker.patch("tempfile.TemporaryDirectory")
     s3_mock = mocker.patch("autogluon.bench.utils.general_utils.download_dir_from_s3")
 
-    run(
-        setup["config_file"],
-        remove_resources=False,
-        wait=False,
-        skip_setup=True,
-        save_hardware_metrics=False,
-    )
+    run(setup["config_file"], remove_resources=False, wait=False, skip_setup=True, save_hardware_metrics=False)
     assert os.environ["FRAMEWORK_PATH"] == "frameworks/tabular"
     assert os.environ["GIT_URI"] == "https://github.com/openml/automlbenchmark.git"
     assert os.environ["GIT_BRANCH"] == "master"
@@ -277,13 +237,7 @@ def test_run_aws_multimodal_custom_dataloader(mocker, tmp_path):
     mount_mock = mocker.patch("autogluon.bench.runbenchmark._mount_dir")
     umount_mock = mocker.patch("autogluon.bench.runbenchmark._umount_if_needed")
 
-    run(
-        setup["config_file"],
-        remove_resources=False,
-        wait=False,
-        skip_setup=True,
-        save_hardware_metrics=False,
-    )
+    run(setup["config_file"], remove_resources=False, wait=False, skip_setup=True, save_hardware_metrics=False)
     assert setup["custom_configs"]["custom_dataloader"]["dataloader_file"] == "custom_configs/dataloaders/dataset.py"
     assert (
         setup["custom_configs"]["custom_dataloader"]["dataset_config_file"]
@@ -294,21 +248,12 @@ def test_run_aws_multimodal_custom_dataloader(mocker, tmp_path):
 
 
 def test_run_aws_multimodal_custom_metrics(mocker, tmp_path):
-    custom_metrics = {
-        "metrics_path": "path_to/metrics.py",
-        "func_name": "custom_score",
-    }
+    custom_metrics = {"metrics_path": "path_to/metrics.py", "func_name": "custom_score"}
     setup = setup_mock(mocker, tmp_path, module="multimodal", custom_metrics=custom_metrics)
     mount_mock = mocker.patch("autogluon.bench.runbenchmark._mount_dir")
     umount_mock = mocker.patch("autogluon.bench.runbenchmark._umount_if_needed")
 
-    run(
-        setup["config_file"],
-        remove_resources=False,
-        wait=False,
-        skip_setup=True,
-        save_hardware_metrics=False,
-    )
+    run(setup["config_file"], remove_resources=False, wait=False, skip_setup=True, save_hardware_metrics=False)
     assert setup["custom_configs"]["custom_metrics"]["metrics_path"] == "custom_configs/metrics/metrics.py"
     assert umount_mock.call_count == 2
     assert mount_mock.call_count == 1
@@ -319,24 +264,14 @@ def test_run_local_mode(mocker, tmp_path):
     config_file.touch()
     mock_open = mocker.patch("builtins.open", new_callable=mocker.mock_open)
 
-    configs = {
-        "mode": "local",
-        "metrics_bucket": "test_bucket",
-        "module": "tabular",
-    }
+    configs = {"mode": "local", "metrics_bucket": "test_bucket", "module": "tabular"}
     mock_yaml = mocker.patch("yaml.safe_load")
     mock_yaml.return_value = configs
     mocker.patch("autogluon.bench.runbenchmark._get_benchmark_name", return_value="test_benchmark")
     mocker.patch("autogluon.bench.runbenchmark.formatted_time", return_value="test_time")
     mock_run_benchmark = mocker.patch("autogluon.bench.runbenchmark.run_benchmark")
 
-    run(
-        str(config_file),
-        remove_resources=False,
-        wait=False,
-        skip_setup=False,
-        save_hardware_metrics=False,
-    )
+    run(str(config_file), remove_resources=False, wait=False, skip_setup=False, save_hardware_metrics=False)
 
     mock_open.assert_called_with(str(config_file), "r")
     mock_run_benchmark.assert_called_with(
@@ -351,12 +286,12 @@ def test_run_local_mode(mocker, tmp_path):
 def test_run_benchmark(mocker):
     benchmark_name = "test_benchmark"
     benchmark_dir = "test_dir"
-    configs = {
-        "module": "tabular",
-        "METRICS_BUCKET": "test_bucket",
-    }
+    configs = {"module": "tabular", "METRICS_BUCKET": "test_bucket"}
 
-    mocker.patch("autogluon.bench.runbenchmark.get_kwargs", return_value={"setup_kwargs": {}, "run_kwargs": {"framework": "AutoGluon:stable"}})
+    mocker.patch(
+        "autogluon.bench.runbenchmark.get_kwargs",
+        return_value={"setup_kwargs": {}, "run_kwargs": {"framework": "AutoGluon:stable"}},
+    )
     setup_mock = mocker.patch("autogluon.bench.runbenchmark.TabularBenchmark.setup")
     run_mock = mocker.patch("autogluon.bench.runbenchmark.TabularBenchmark.run")
     upload_metrics_mock = mocker.patch("autogluon.bench.runbenchmark.TabularBenchmark.upload_metrics")
@@ -374,12 +309,12 @@ def test_run_benchmark(mocker):
 def test_run_benchmark_skip_setup(mocker):
     benchmark_name = "test_benchmark"
     benchmark_dir = "test_dir"
-    configs = {
-        "module": "tabular",
-        "METRICS_BUCKET": "test_bucket",
-    }
+    configs = {"module": "tabular", "METRICS_BUCKET": "test_bucket"}
 
-    mocker.patch("autogluon.bench.runbenchmark.get_kwargs", return_value={"setup_kwargs": {}, "run_kwargs": {"framework": "AutoGluon:stable"}})
+    mocker.patch(
+        "autogluon.bench.runbenchmark.get_kwargs",
+        return_value={"setup_kwargs": {}, "run_kwargs": {"framework": "AutoGluon:stable"}},
+    )
     setup_mock = mocker.patch("autogluon.bench.runbenchmark.TabularBenchmark.setup")
     run_mock = mocker.patch("autogluon.bench.runbenchmark.TabularBenchmark.run")
     upload_metrics_mock = mocker.patch("autogluon.bench.runbenchmark.TabularBenchmark.upload_metrics")
@@ -473,12 +408,7 @@ def test_run_aws_timeseries_user_dir(mocker, tmp_path):
     temp_dir_mock = mocker.patch("tempfile.TemporaryDirectory")
     s3_mock = mocker.patch("autogluon.bench.utils.general_utils.download_dir_from_s3")
 
-    run(
-        setup["config_file"],
-        remove_resources=False,
-        wait=False,
-        skip_setup=True,
-    )
+    run(setup["config_file"], remove_resources=False, wait=False, skip_setup=True)
     assert os.environ["FRAMEWORK_PATH"] == "frameworks/timeseries"
     assert os.environ["GIT_URI"] == "https://github.com/openml/automlbenchmark.git"
     assert os.environ["GIT_BRANCH"] == "master"
@@ -493,12 +423,12 @@ def test_run_aws_timeseries_user_dir(mocker, tmp_path):
 def test_run_benchmark_timeseries(mocker):
     benchmark_name = "test_benchmark"
     benchmark_dir = "test_dir"
-    configs = {
-        "module": "timeseries",
-        "METRICS_BUCKET": "test_bucket",
-    }
+    configs = {"module": "timeseries", "METRICS_BUCKET": "test_bucket"}
 
-    mocker.patch("autogluon.bench.runbenchmark.get_kwargs", return_value={"setup_kwargs": {}, "run_kwargs": {"framework": "AutoGluon:stable"}})
+    mocker.patch(
+        "autogluon.bench.runbenchmark.get_kwargs",
+        return_value={"setup_kwargs": {}, "run_kwargs": {"framework": "AutoGluon:stable"}},
+    )
     setup_mock = mocker.patch("autogluon.bench.runbenchmark.TimeSeriesBenchmark.setup")
     run_mock = mocker.patch("autogluon.bench.runbenchmark.TimeSeriesBenchmark.run")
     upload_metrics_mock = mocker.patch("autogluon.bench.runbenchmark.TimeSeriesBenchmark.upload_metrics")

--- a/tests/unittests/benchmark/test_runbenchmarks.py
+++ b/tests/unittests/benchmark/test_runbenchmarks.py
@@ -302,7 +302,7 @@ def test_run_benchmark(mocker):
     )
 
     setup_mock.assert_called_once_with()
-    run_mock.assert_called_once_with()
+    run_mock.assert_called_once_with(framework="AutoGluon:stable")
     upload_metrics_mock.assert_called_once_with(s3_bucket=configs["METRICS_BUCKET"], s3_dir="s3_dir")
 
 
@@ -329,7 +329,7 @@ def test_run_benchmark_skip_setup(mocker):
     )
 
     setup_mock.assert_not_called()
-    run_mock.assert_called_once_with()
+    run_mock.assert_called_once_with(framework="AutoGluon:stable")
     upload_metrics_mock.assert_called_once_with(s3_bucket=configs["METRICS_BUCKET"], s3_dir="s3_dir")
 
 
@@ -439,5 +439,5 @@ def test_run_benchmark_timeseries(mocker):
     )
 
     setup_mock.assert_called_once_with()
-    run_mock.assert_called_once_with()
+    run_mock.assert_called_once_with(framework="AutoGluon:stable")
     upload_metrics_mock.assert_called_once_with(s3_bucket=configs["METRICS_BUCKET"], s3_dir="s3_dir")


### PR DESCRIPTION
Description of changes:

This PR is an improvement on the way benchmark results are stored in AutoGluon Bench.
Initially the storage in S3 occurred in the following manner `s3://bucket-name/module-name/agbench_timestamp/agbench_timestamp_0`
Which in turn made it hard to fetch logs for a particular task in case a benchmark run failed.
This PR now stores it in the following manner `s3://bucket-name/module-name/agbench_timestamp/autogluon_module_preset.benchmark.dataset_name.constraint.local_mode/aws_mode.fold`
and example of this will be `s3://bucket-name/tabular/agbench_202407182105/autogluon_tabular_best.tabular_full.Australian.1h8c.local.5`

This makes it easier to fetch logs and unifies the naming system to that of AutoML Benchmark.
<img width="1356" alt="Bench_improvement" src="https://github.com/user-attachments/assets/d23d390c-bc24-44fe-b791-8b1b935b85e7">

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.