### PR TITLE
Update TIME_LIMIT in cloud configuration files to 24 hours and adjust multimodal constraints to 10 minutes accordingly

### DIFF
--- a/sample_configs/resources/multimodal_constraints.yaml
+++ b/sample_configs/resources/multimodal_constraints.yaml
@@ -1,5 +1,5 @@
 10m4x:
-  TIME_LIMIT: 100
+  TIME_LIMIT: 600  # 10 minutes
   INSTANCE: g4dn.4xlarge
   # MAX_MACHINE_NUM: 20   # optional, default 20
   # BLOCK_DEVICE_VOLUME: 100   # optional, default 100GB

--- a/sample_configs/tabular_cloud_configs.yaml
+++ b/sample_configs/tabular_cloud_configs.yaml
@@ -9,7 +9,7 @@ cdk_context:  # AWS infra configs used to setup AWS Batch environment with AWS C
   # BLOCK_DEVICE_VOLUME: 100   # optional, default 100GB
   # RESERVED_MEMORY_SIZE: 15000  # optional, default 15000MB
   # INSTANCE: g4dn.2xlarge  # optional, default g4dn.2xlarge
-  # TIME_LIMIT: 3600  # optional, EC2 timeout, default 3600s
+  TIME_LIMIT: 86400  # 24 hours in seconds for (buffer will be added automatically for instance start, dataset download and overhead)
   # VPC_NAME: existing-vpc-name  # optional
 
 # Benchmark configurations

--- a/sample_configs/timeseries_cloud_configs.yaml
+++ b/sample_configs/timeseries_cloud_configs.yaml
@@ -9,7 +9,7 @@ cdk_context:  # AWS infra configs used to setup AWS Batch environment with AWS C
   # BLOCK_DEVICE_VOLUME: 100   # optional, default 100GB
   # RESERVED_MEMORY_SIZE: 15000  # optional, default 15000MB
   # INSTANCE: g4dn.2xlarge  # optional, default g4dn.2xlarge
-  # TIME_LIMIT: 3600  # optional, EC2 timeout, default 3600s
+  TIME_LIMIT: 86400  # 24 hours in seconds for (buffer will be added automatically for instance start, dataset download and overhead)
   # VPC_NAME: existing-vpc-name  # optional
 
 # Benchmark configurations


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Update TIME_LIMIT in cloud configuration files to 24 hours and adjust multimodal constraints to 10 minutes accordingly


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.