### PR TITLE
Change time_limit parameter type from str to int

### DIFF
--- a/src/autogluon/bench/cloud/aws/stack_handler.py
+++ b/src/autogluon/bench/cloud/aws/stack_handler.py
@@ -66,7 +66,7 @@ def construct_context(custom_configs: dict) -> dict:
         instance_type=configs["INSTANCE"], region=configs["CDK_DEPLOY_REGION"]
     )
     configs["TIME_LIMIT"] = (
-        configs["TIME_LIMIT"] + 3600
+        int(configs["TIME_LIMIT"]) + 3600
     )  # buffer to account for instance start, dataset download and overhead
 
     context_to_parse = {

--- a/src/autogluon/bench/scripts/generate_cloud_configs.py
+++ b/src/autogluon/bench/scripts/generate_cloud_configs.py
@@ -26,9 +26,9 @@ def generate_cloud_config(
         None, help="Reserved memory size for Docker container (optional, default = 15000)"
     ),
     instance: str = typer.Option(None, help="EC2 Instance type (optional, default = 'g4dn.2xlarge')"),
-    time_limit: str = typer.Option(
+    time_limit: int = typer.Option(
         None,
-        help="AWS Batch job time out",
+        help="AWS Batch job timeout in seconds (e.g., 86400 for 24 hours)",
     ),
     vpc_name: str = typer.Option(None, help="Existing VPC name (optional, default: create a new VPC)"),
     git_uri_branch: str = typer.Option("", help="AMLB git_uri#branch"),
@@ -108,7 +108,7 @@ def generate_cloud_config(
     if instance:
         cdk_context["INSTANCE"] = instance
     if time_limit:
-        cdk_context["TIME_LIMIT"] = time_limit
+        cdk_context["TIME_LIMIT"] = int(time_limit) if isinstance(time_limit, str) else time_limit
 
     config["cdk_context"] = cdk_context
 


### PR DESCRIPTION
…nfig function for improved clarity on AWS Batch job timeout in seconds.

Issue #, if available:

Description of changes:
Change time_limit parameter type from str to int

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.